### PR TITLE
Refactor UI for search live subject

### DIFF
--- a/packages/client/src/components/AlarmButton.tsx
+++ b/packages/client/src/components/AlarmButton.tsx
@@ -1,0 +1,18 @@
+import { Link } from 'react-router-dom';
+
+function AlarmButton() {
+  return (
+    <Link
+      to="/live/search"
+      className="p-2 rounded-full flex items-center justify-center"
+      aria-label="여석 알림 과목 추가"
+      title="여석 알림 과목 추가"
+    >
+      <div className="bg-gray-50 rounded-full px-4 py-2 text-sm border border-gray-200 hover:shadow-md">
+        + 핀 알림 과목 등록
+      </div>
+    </Link>
+  );
+}
+
+export default AlarmButton;

--- a/packages/client/src/components/Navbar.tsx
+++ b/packages/client/src/components/Navbar.tsx
@@ -2,7 +2,7 @@ import { NavLink } from 'react-router-dom';
 
 const NavLinks = [
   { title: '실시간', path: '/live', end: true },
-  { title: '과목 검색', path: '/live/search', end: false },
+  { title: '알림과목 등록', path: '/live/search', end: false },
 ];
 
 const Navbar = () => {

--- a/packages/client/src/components/PinnedCourses.tsx
+++ b/packages/client/src/components/PinnedCourses.tsx
@@ -1,5 +1,4 @@
 import { useState } from 'react';
-import { Link } from 'react-router-dom';
 import Tooltip from '@/components/common/Tooltip.tsx';
 import AlarmOptionModal from '@/components/toast/AlarmOptionModal.tsx';
 import RealtimeCard from '@/components/subjectTable/RealtimeCard.tsx';
@@ -11,8 +10,8 @@ import { SSEType, useSseData } from '@/hooks/useSSEManager.ts';
 import useNotification from '@/hooks/useNotification.ts';
 import AlarmBlueIcon from '@/assets/alarm-blue.svg?react';
 import AlarmDisabledIcon from '@/assets/alarm-disabled.svg?react';
-import AddBlueIcon from '@/assets/add-blue.svg?react';
 import SettingSvg from '@/assets/settings.svg?react';
+import AlarmButton from './AlarmButton';
 
 const PinnedCourses = () => {
   const { data, isPending, isError, refetch } = usePinned();
@@ -67,14 +66,6 @@ const PinnedCourses = () => {
             >
               {isAlarm ? <AlarmBlueIcon className="w-5 h-5" /> : <AlarmDisabledIcon className="w-5 h-5" />}
             </button>
-            <Link
-              to="/live/search"
-              className="p-2 rounded-full hover:bg-blue-100"
-              aria-label="여석 알림 과목 추가"
-              title="여석 알림 과목 추가"
-            >
-              <AddBlueIcon className="w-5 h-5" />
-            </Link>
           </div>
         </div>
 
@@ -103,6 +94,7 @@ const PinnedCourses = () => {
                 queryTime={getQueryTime(subject.subjectId)}
               />
             ))}
+            {pinnedWishes.length < 5 && <AlarmButton />}
           </div>
         )}
       </div>

--- a/packages/client/src/components/dashboard/errors/ZeroPinError.tsx
+++ b/packages/client/src/components/dashboard/errors/ZeroPinError.tsx
@@ -1,3 +1,4 @@
+import AlarmButton from '@/components/AlarmButton';
 import NoneLayout from '@/components/dashboard/NoneLayout.tsx';
 import AlarmIcon from '@/components/svgs/AlarmIcon.tsx';
 
@@ -5,9 +6,11 @@ function ZeroPinError() {
   return (
     <NoneLayout
       title="핀 고정된 과목이 없습니다"
-      description="관심있는 과목을 찾아 핀으로 고정해보세요"
+      description="관심있는 과목을 찾아 핀으로 고정해보세요. 핀으로 고정된 과목은 여석이 생길 시 알림이 울려요."
       icon={<AlarmIcon className="w-7 h-7" disabled />}
-    />
+    >
+      <AlarmButton />
+    </NoneLayout>
   );
 }
 


### PR DESCRIPTION
### 작업내용

여석 과목 알림 UI를 개선해보았어요

1. 핀 알림과목 등록 버튼 개선
핀 알림 등록 버튼을 조금 더 잘 보일 수 있게 버튼 형태로 카드 리스트 옆에 추가했습니다.
카드가 5개가 넘어가면 버튼은 사라져요.

2. 탭 이름 변경
추가로 기존 과목 검색 탭을 알림 과목 등록으로 변경하였습니다.

3. 메시지 추가 
핀으로 고정된 과목이 없을 경우 "핀으로 고정된 과목은 여석이 생길 시 알림을 보내드려요"라는 메시지를 추가하였습니다!