### PR TITLE
fix: simulation 학과 선택 모달 오류 수정

### DIFF
--- a/packages/client/src/components/simulation/SimulationSearchForm.tsx
+++ b/packages/client/src/components/simulation/SimulationSearchForm.tsx
@@ -16,9 +16,13 @@ function SimulationSearchForm() {
     ongoingSimulation && 'userStatus' in ongoingSimulation ? ongoingSimulation.userStatus?.departmentName : -1;
 
   const handleClickRestart = () => {
-    if (hasRunningSimulationId === -1 && currentSimulation.simulationStatus !== 'progress') {
-      openModal('wish');
-    }
+    setCurrentSimulation({
+      simulationStatus: 'before',
+    });
+
+    // if (hasRunningSimulationId === -1 && currentSimulation.simulationStatus !== 'progress') {
+    //   openModal('wish');
+    // }
   };
 
   const handleStartSimulation = async () => {
@@ -34,6 +38,8 @@ function SimulationSearchForm() {
             simulationStatus: 'progress',
             clickedTime: elapsedSeconds > 10 ? 5 : elapsedSeconds,
           });
+
+          console.log(currentSimulation.simulationStatus);
 
           openModal('waiting');
         }

--- a/packages/client/src/components/simulation/SimulationSearchForm.tsx
+++ b/packages/client/src/components/simulation/SimulationSearchForm.tsx
@@ -20,9 +20,7 @@ function SimulationSearchForm() {
       simulationStatus: 'before',
     });
 
-    // if (hasRunningSimulationId === -1 && currentSimulation.simulationStatus !== 'progress') {
-    //   openModal('wish');
-    // }
+    openModal('wish');
   };
 
   const handleStartSimulation = async () => {

--- a/packages/client/src/components/simulation/SimulationSearchForm.tsx
+++ b/packages/client/src/components/simulation/SimulationSearchForm.tsx
@@ -5,7 +5,7 @@ import SearchSvg from '@/assets/search-white.svg?react';
 import { BUTTON_EVENT, checkOngoingSimulation, triggerButtonEvent } from '@/utils/simulation/simulation';
 
 function SimulationSearchForm() {
-  const { currentSimulation, setCurrentSimulation } = useSimulationProcessStore();
+  const { currentSimulation, setCurrentSimulation, resetSimulation } = useSimulationProcessStore();
   const { openModal } = useSimulationModalStore();
   const ongoingSimulation = useLiveQuery(checkOngoingSimulation);
 
@@ -21,6 +21,7 @@ function SimulationSearchForm() {
     });
 
     openModal('wish');
+    resetSimulation();
   };
 
   const handleStartSimulation = async () => {

--- a/packages/client/src/components/simulation/SimulationSearchForm.tsx
+++ b/packages/client/src/components/simulation/SimulationSearchForm.tsx
@@ -38,8 +38,6 @@ function SimulationSearchForm() {
             clickedTime: elapsedSeconds > 10 ? 5 : elapsedSeconds,
           });
 
-          console.log(currentSimulation.simulationStatus);
-
           openModal('waiting');
         }
       })

--- a/packages/client/src/components/simulation/modal/SimulationModal.tsx
+++ b/packages/client/src/components/simulation/modal/SimulationModal.tsx
@@ -63,7 +63,6 @@ function SimulationModal({ reloadSimulationStatus }: ISimulationModal) {
       if (forceFinish) {
         forceStopSimulation().then(() => {
           openModal('result');
-          // resetSimulation();
         });
       }
 

--- a/packages/client/src/components/simulation/modal/SimulationModal.tsx
+++ b/packages/client/src/components/simulation/modal/SimulationModal.tsx
@@ -43,7 +43,7 @@ interface ISimulationModal {
 function SimulationModal({ reloadSimulationStatus }: ISimulationModal) {
   const { closeModal, openModal } = useSimulationModalStore();
   const { currentSubjectId, setSubjectStatus, subjectStatusMap } = useSimulationSubjectStore();
-  const { resetSimulation } = useSimulationProcessStore();
+  const { setCurrentSimulation } = useSimulationProcessStore();
 
   const currentSubjectStatus = subjectStatusMap[currentSubjectId];
   const modalData = SIMULATION_MODAL_CONTENTS.find(data => data.status === currentSubjectStatus);
@@ -63,7 +63,7 @@ function SimulationModal({ reloadSimulationStatus }: ISimulationModal) {
       if (forceFinish) {
         forceStopSimulation().then(() => {
           openModal('result');
-          resetSimulation();
+          // resetSimulation();
         });
       }
 
@@ -91,6 +91,9 @@ function SimulationModal({ reloadSimulationStatus }: ISimulationModal) {
     reloadSimulationStatus();
 
     if (result.finished) {
+      setCurrentSimulation({
+        simulationStatus: 'finish',
+      });
       openModal('result');
     }
 
@@ -103,10 +106,15 @@ function SimulationModal({ reloadSimulationStatus }: ISimulationModal) {
       if ('errMsg' in result) {
         alert(result.errMsg);
         await forceStopSimulation();
-        resetSimulation();
 
+        setCurrentSimulation({
+          simulationStatus: 'finish',
+        });
         openModal('result');
       } else if (result.finished) {
+        setCurrentSimulation({
+          simulationStatus: 'finish',
+        });
         openModal('result');
       }
     } catch (error) {
@@ -152,9 +160,17 @@ function SimulationModal({ reloadSimulationStatus }: ISimulationModal) {
         if ('errMsg' in result) {
           alert(result.errMsg);
           await forceStopSimulation();
-          resetSimulation();
+
+          setCurrentSimulation({
+            simulationStatus: 'finish',
+          });
+
           openModal('result');
         } else if (result.finished) {
+          setCurrentSimulation({
+            simulationStatus: 'finish',
+          });
+
           openModal('result');
         }
 

--- a/packages/client/src/components/simulation/modal/SimulationResultModal.tsx
+++ b/packages/client/src/components/simulation/modal/SimulationResultModal.tsx
@@ -3,12 +3,10 @@ import { useSimulationModalStore } from '@/store/simulation/useSimulationModal';
 import { getSummaryResult } from '@/utils/simulation/simulation';
 import { useEffect, useState } from 'react';
 import ProcessingModal from './Processing';
-import useSimulationProcessStore from '@/store/simulation/useSimulationProcess';
 import { NavLink } from 'react-router-dom';
 
 function SimulationResultModal({ simulationId }: { simulationId: number }) {
   const { closeModal } = useSimulationModalStore();
-  const { resetSimulation } = useSimulationProcessStore();
   const [result, setResult] = useState<{ accuracy: number; score: number; total_elapsed: number } | null>(null);
   const [logParam, setLogParam] = useState<number>();
 
@@ -20,7 +18,6 @@ function SimulationResultModal({ simulationId }: { simulationId: number }) {
         } else {
           setResult(result);
           setLogParam(simulationId);
-          resetSimulation();
         }
       });
     }

--- a/packages/client/src/components/simulation/modal/UserWishModal.tsx
+++ b/packages/client/src/components/simulation/modal/UserWishModal.tsx
@@ -138,12 +138,6 @@ function UserWishModal({ department, setIsModalOpen }: UserWishModalIProp) {
         },
       });
     }
-
-    if (currentSimulation.department.departmentName !== '') {
-      setCurrentSimulation({
-        simulationStatus: 'selectedDepartment',
-      });
-    }
   };
 
   return (

--- a/packages/client/src/hooks/useReloadSimulation.ts
+++ b/packages/client/src/hooks/useReloadSimulation.ts
@@ -1,0 +1,53 @@
+import { getSimulateStatus } from '@/utils/simulation/subjects';
+import { findSubjectsById } from '@/utils/subjectPicker';
+import { SimulationSubject } from '@/utils/types';
+import useSimulationProcessStore from '@/store/simulation/useSimulationProcess';
+
+export function useReloadSimulation() {
+  const { setCurrentSimulation } = useSimulationProcessStore();
+
+  const loadCurrentSimulation = (
+    subjects: { subjectId: number }[],
+    key: 'nonRegisteredSubjects' | 'registeredSubjects',
+    simulationId: number,
+  ) => {
+    const filteredSubjects = subjects
+      .map(subject => findSubjectsById(subject.subjectId))
+      .filter((subject): subject is SimulationSubject => subject !== undefined);
+
+    setCurrentSimulation({
+      simulationId: simulationId,
+      [key]: filteredSubjects,
+    });
+  };
+
+  const reloadSimulationStatus = () => {
+    getSimulateStatus()
+      .then(result => {
+        if (!result || result.simulationId === -1) return;
+
+        setCurrentSimulation({
+          simulationId: result.simulationId,
+          department: {
+            departmentCode: result?.userStatus?.departmentCode ?? '',
+            departmentName: result?.userStatus?.departmentName ?? '',
+          },
+        });
+
+        if (result?.nonRegisteredSubjects) {
+          loadCurrentSimulation(result.nonRegisteredSubjects, 'nonRegisteredSubjects', result.simulationId);
+        }
+
+        if (result?.registeredSubjects) {
+          loadCurrentSimulation(result.registeredSubjects, 'registeredSubjects', result.simulationId);
+        }
+      })
+      .catch(error => {
+        console.log(error);
+      });
+  };
+
+  return {
+    reloadSimulationStatus,
+  };
+}

--- a/packages/client/src/pages/simulation/Simulation.tsx
+++ b/packages/client/src/pages/simulation/Simulation.tsx
@@ -52,9 +52,9 @@ function Simulation() {
 
   const checkHasSimulation = () => {
     checkOngoingSimulation().then(simulation => {
-      if (simulation && 'simulationId' in simulation && typeof simulation.simulationId === 'number') {
+      if (simulation && 'simulationId' in simulation && simulation.simulationId !== -1) {
         reloadSimulationStatus();
-      } else if (currentSimulation.simulationStatus === 'before' || currentSimulation.simulationStatus !== 'start') {
+      } else if (currentSimulation.simulationStatus === 'before') {
         openModal('wish');
       }
     });
@@ -64,6 +64,7 @@ function Simulation() {
     /**
      * 새로고침 시 진행 중인 시뮬레이션이 있다면
      * 현재 시뮬레이션으로 저장
+     * 과목 데이터 나눌 때 호출
      */
     checkHasSimulation();
   }, [currentSimulation.simulationStatus]);

--- a/packages/client/src/pages/simulation/Simulation.tsx
+++ b/packages/client/src/pages/simulation/Simulation.tsx
@@ -64,7 +64,6 @@ function Simulation() {
     /**
      * 새로고침 시 진행 중인 시뮬레이션이 있다면
      * 현재 시뮬레이션으로 저장
-     * 과목 데이터 나눌 때 호출
      */
     checkHasSimulation();
   }, [currentSimulation.simulationStatus]);

--- a/packages/client/src/pages/simulation/Simulation.tsx
+++ b/packages/client/src/pages/simulation/Simulation.tsx
@@ -51,8 +51,11 @@ function Simulation() {
   const { currentSimulation, setCurrentSimulation } = useSimulationProcessStore();
   const ongoingSimulation = useLiveQuery(checkOngoingSimulation);
 
-  const hasOngoingSimulation =
-    ongoingSimulation && 'simulationId' in ongoingSimulation && ongoingSimulation.simulationId !== -1;
+  // const hasOngoingSimulation =
+  //   ongoingSimulation && 'simulationId' in ongoingSimulation && ongoingSimulation.simulationId !== -1;
+
+  const hasRunningSimulationId =
+    ongoingSimulation && 'simulationId' in ongoingSimulation ? ongoingSimulation.simulationId : -1;
   const currentModal = useSimulationModalStore(state => state.type);
 
   const loadCurrentSimulation = (
@@ -66,16 +69,11 @@ function Simulation() {
 
     setCurrentSimulation({
       simulationId: simulationId,
-      simulationStatus: 'progress',
       [key]: filteredSubjects,
     });
   };
 
   const reloadSimulationStatus = () => {
-    // if (currentSimulation.simulationStatus === 'progress') {
-    //   openModal('waiting');
-    // }
-
     getSimulateStatus()
       .then(result => {
         if (!result || result.simulationId === -1) return;
@@ -106,10 +104,7 @@ function Simulation() {
      * 새로고침 시 진행 중인 시뮬레이션이 있다면
      * 현재 시뮬레이션으로 저장
      */
-
-    if (!hasOngoingSimulation) return;
-
-    if (hasOngoingSimulation) {
+    if (hasRunningSimulationId) {
       reloadSimulationStatus();
     } else if (currentSimulation.simulationStatus === 'before' || currentSimulation.simulationStatus === 'start') {
       openModal('wish');
@@ -155,12 +150,8 @@ function Simulation() {
           <table className="w-full border border-gray-300 border-t-3 text-xs border-t-black text-center">
             <SimulationSubjectsHeader />
 
-            {hasOngoingSimulation ? (
-              currentSimulation.simulationStatus === 'progress' && currentModal !== 'waiting' ? (
-                <SubjectsTable isRegisteredTable={false} />
-              ) : (
-                <NothingTable />
-              )
+            {currentSimulation.simulationStatus === 'progress' && currentModal !== 'waiting' ? (
+              <SubjectsTable isRegisteredTable={false} />
             ) : (
               <NothingTable />
             )}
@@ -193,12 +184,8 @@ function Simulation() {
           <table className="w-full border border-gray-300 border-t-3 text-xs border-t-black text-center">
             <SimulationSubjectsHeader />
 
-            {hasOngoingSimulation ? (
-              currentSimulation.simulationStatus === 'progress' && currentModal !== 'waiting' ? (
-                <SubjectsTable isRegisteredTable={true} />
-              ) : (
-                <NothingTable />
-              )
+            {currentSimulation.simulationStatus === 'progress' && currentModal !== 'waiting' ? (
+              <SubjectsTable isRegisteredTable={true} />
             ) : (
               <NothingTable />
             )}

--- a/packages/client/src/pages/simulation/Simulation.tsx
+++ b/packages/client/src/pages/simulation/Simulation.tsx
@@ -53,7 +53,6 @@ function Simulation() {
 
   const hasOngoingSimulation =
     ongoingSimulation && 'simulationId' in ongoingSimulation && ongoingSimulation.simulationId !== -1;
-
   const currentModal = useSimulationModalStore(state => state.type);
 
   const loadCurrentSimulation = (
@@ -73,9 +72,9 @@ function Simulation() {
   };
 
   const reloadSimulationStatus = () => {
-    if (currentSimulation.simulationStatus === 'progress') {
-      openModal('waiting');
-    }
+    // if (currentSimulation.simulationStatus === 'progress') {
+    //   openModal('waiting');
+    // }
 
     getSimulateStatus()
       .then(result => {
@@ -107,15 +106,12 @@ function Simulation() {
      * 새로고침 시 진행 중인 시뮬레이션이 있다면
      * 현재 시뮬레이션으로 저장
      */
-    if (
-      hasOngoingSimulation &&
-      currentSimulation.simulationStatus !== 'selectedDepartment' &&
-      currentSimulation.simulationStatus !== 'start'
-    ) {
-      reloadSimulationStatus();
-    }
 
-    if (!hasOngoingSimulation && currentSimulation.simulationStatus !== 'progress') {
+    if (!hasOngoingSimulation) return;
+
+    if (hasOngoingSimulation) {
+      reloadSimulationStatus();
+    } else if (currentSimulation.simulationStatus === 'before' || currentSimulation.simulationStatus === 'start') {
       openModal('wish');
     }
   }, [currentSimulation.simulationStatus]);

--- a/packages/client/src/pages/simulation/Simulation.tsx
+++ b/packages/client/src/pages/simulation/Simulation.tsx
@@ -8,13 +8,10 @@ import SubjectsTable from '@/components/simulation/table/SubjectsTable';
 import { useSimulationModalStore } from '@/store/simulation/useSimulationModal';
 import useSimulationProcessStore from '@/store/simulation/useSimulationProcess';
 import { checkOngoingSimulation } from '@/utils/simulation/simulation';
-import { getSimulateStatus } from '@/utils/simulation/subjects';
-import { findSubjectsById } from '@/utils/subjectPicker';
-import { SimulationSubject } from '@/utils/types';
-import { useLiveQuery } from 'dexie-react-hooks';
 import { useEffect } from 'react';
 import { Helmet } from 'react-helmet';
 import SimulationSearchForm from '@/components/simulation/SimulationSearchForm';
+import { useReloadSimulation } from '@/hooks/useReloadSimulation';
 
 const SUBJECTS_COLUMNS_HEADER = [
   '순번',
@@ -48,55 +45,19 @@ function SimulationSubjectsHeader() {
 
 function Simulation() {
   const { type, openModal, closeModal } = useSimulationModalStore();
-  const { currentSimulation, setCurrentSimulation } = useSimulationProcessStore();
-  const ongoingSimulation = useLiveQuery(checkOngoingSimulation);
+  const { currentSimulation } = useSimulationProcessStore();
+  const { reloadSimulationStatus } = useReloadSimulation();
 
-  // const hasOngoingSimulation =
-  //   ongoingSimulation && 'simulationId' in ongoingSimulation && ongoingSimulation.simulationId !== -1;
-
-  const hasRunningSimulationId =
-    ongoingSimulation && 'simulationId' in ongoingSimulation ? ongoingSimulation.simulationId : -1;
   const currentModal = useSimulationModalStore(state => state.type);
 
-  const loadCurrentSimulation = (
-    subjects: { subjectId: number }[],
-    key: 'nonRegisteredSubjects' | 'registeredSubjects',
-    simulationId: number,
-  ) => {
-    const filteredSubjects = subjects
-      .map(subject => findSubjectsById(subject.subjectId))
-      .filter((subject): subject is SimulationSubject => subject !== undefined);
-
-    setCurrentSimulation({
-      simulationId: simulationId,
-      [key]: filteredSubjects,
+  const checkHasSimulation = () => {
+    checkOngoingSimulation().then(simulation => {
+      if (simulation && 'simulationId' in simulation && typeof simulation.simulationId === 'number') {
+        reloadSimulationStatus();
+      } else if (currentSimulation.simulationStatus === 'before' || currentSimulation.simulationStatus !== 'start') {
+        openModal('wish');
+      }
     });
-  };
-
-  const reloadSimulationStatus = () => {
-    getSimulateStatus()
-      .then(result => {
-        if (!result || result.simulationId === -1) return;
-
-        setCurrentSimulation({
-          simulationId: result.simulationId,
-          department: {
-            departmentCode: result?.userStatus?.departmentCode ?? '',
-            departmentName: result?.userStatus?.departmentName ?? '',
-          },
-        });
-
-        if (result?.nonRegisteredSubjects) {
-          loadCurrentSimulation(result.nonRegisteredSubjects, 'nonRegisteredSubjects', result.simulationId);
-        }
-
-        if (result?.registeredSubjects) {
-          loadCurrentSimulation(result.registeredSubjects, 'registeredSubjects', result.simulationId);
-        }
-      })
-      .catch(error => {
-        console.log(error);
-      });
   };
 
   useEffect(() => {
@@ -104,11 +65,7 @@ function Simulation() {
      * 새로고침 시 진행 중인 시뮬레이션이 있다면
      * 현재 시뮬레이션으로 저장
      */
-    if (hasRunningSimulationId) {
-      reloadSimulationStatus();
-    } else if (currentSimulation.simulationStatus === 'before' || currentSimulation.simulationStatus === 'start') {
-      openModal('wish');
-    }
+    checkHasSimulation();
   }, [currentSimulation.simulationStatus]);
 
   const totalCredits = currentSimulation.registeredSubjects.reduce((acc, subject) => {

--- a/packages/client/src/utils/types.ts
+++ b/packages/client/src/utils/types.ts
@@ -54,7 +54,7 @@ export interface SimulationSubject {
   tm_num: string;
 }
 
-export type SimulationStatusType = 'before' | 'selectedDepartment' | 'start' | 'progress' | 'finish' | 'refresh';
+export type SimulationStatusType = 'before' | 'start' | 'progress' | 'finish';
 
 export interface DepartmentType {
   departmentCode: string;

--- a/packages/e2e/tests/simulation.spec.ts
+++ b/packages/e2e/tests/simulation.spec.ts
@@ -41,7 +41,6 @@ async function applyWithCaptcha(page: Page, index: number) {
     await page.getByRole('button', { name: '확인' }).click();
   } else {
     await page.getByRole('button', { name: '취소' }).click();
-
   }
 }
 
@@ -79,6 +78,7 @@ test.describe('수강신청 시뮬레이션 예외 상황', () => {
 
     await page.getByRole('button', { name: '확인' }).click();
 
+    await page.getByRole('button', { name: '검색' }).click();
     await expectVisibleModal(page, '서비스 접속대기 중입니다.');
   });
 });
@@ -112,5 +112,4 @@ test.describe('수강신청 시뮬레이션 전체 흐름', () => {
 
     await expectVisibleModal(page, '수강 신청 성공!');
   });
-
 });


### PR DESCRIPTION
## 작업 내용
- 학과 선택 모달 두 번 뜨는 문제 수정
- 시뮬레이션 상태 재호출하는 로직 custom훅으로 분리
- 테스트 코드 수정

### 학과 선택 모달 두 번 뜨는 문제 
시뮬레이션 중간에 새로 고침시, checkOngoingSimulation 함수로 현재 진행 중인 시뮬레이션이 있는지 판별합니다. 

1. 시뮬레이션이 존재하는 경우
     기존 시뮬레이션이 존재하는 경우 이전 과목 신청 여부 및 모든 데이터를 불러옵니다. 검색 버튼을 누를 시 게임이 재진행됩니다.
    
3. 시뮬레이션이 존재하지 않는 경우
    기존 시뮬레이션이 존재하지 않는 경우 모달을 띄우고 새로 시작합니다. 
    

### 문제 상황

`useLiveQuery`의 동작 방식이 문제였던 것으로 파악됩니다. (useLiveQuery를 사용하지 않는 나머지 비동기 로직들은 잘 실행되었었어요)
useLiveQuery에 대해서 찾아봤는데, `useLiveQuery`는 `Promise`가 resolve되기 전에 우선 `undefined`를 반환하여 컴포넌트가 렌더링 될 수 있게 한다고 합니다.
그 후 실제 값이 들어오면 리렌더링이 발생하면서 WishModal이 다시 호출되는 현상이 있었습니다.

따라서 `useLiveQuery`를 통한 비동기 호출 대신, `checkOngoingSimulation`을 직접 호출하여 `Promise`를 즉시 처리하도록 수정하였습니다!

```js
  const checkHasSimulation = () => {
    checkOngoingSimulation().then(simulation => {
      if (simulation && 'simulationId' in simulation && typeof simulation.simulationId === 'number') {
        reloadSimulationStatus();
      } else if (currentSimulation.simulationStatus === 'before') {
        openModal('wish');
      }
    });
  };
```

### 추가 이슈

시뮬레이션이 종료되었을 때 `resetSimuation`으로 상태를 초기화하여 result 모달 대신 wish 모달이 뜨는 이슈가 생겼습니다.

→ `resetSimuation` 조건을 wish모달을 띄운 직후로 변경하였습니다.

## 변경 사항 및 리뷰 포인트

