### PR TITLE
feat: 필터링 훅 구현 및 리팩토링

### DIFF
--- a/packages/client/src/components/contentPanel/ContentPanel.tsx
+++ b/packages/client/src/components/contentPanel/ContentPanel.tsx
@@ -1,86 +1,22 @@
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
 import SearchBox from '../common/SearchBox';
 import DepartmentFilter from './filter/DepartmentFilter';
 import GradeFilter from './filter/GradeFilter';
 import DayFilter from './filter/DayFilter';
 import { FilteredSubjectCards } from './subject/FilteredSubjectCards';
-import { disassemble } from 'es-hangul';
 import useSubject from '@/hooks/server/useSubject';
-import { SubjectApiResponse } from '@/utils/types';
-import { useFilterScheduleStore } from '@/store/useFilterScheduleStore';
 import useScheduleModal from '@/hooks/useScheduleModal.ts';
 import { ScheduleAdapter } from '@/utils/timetable/adapter.ts';
 import FilterDelete from '@/components/contentPanel/filter/FilterDelete.tsx';
+import useFilteringSubjects from '@/hooks/useFilteringSubjects';
 
 const initSchedule = new ScheduleAdapter().toUiData();
 
 function ContentPanel() {
   const { data: subjects = [], isPending } = useSubject();
-  const { selectedDepartment, selectedGrades, selectedDays } = useFilterScheduleStore();
   const [searchKeywords, setSearchKeywords] = useState('');
-
   const { openScheduleModal } = useScheduleModal();
-
-  const handleCreateSchedule = () => {
-    openScheduleModal(initSchedule);
-  };
-
-  const filteredData = useMemo(() => {
-    if (!subjects) return [];
-
-    return subjects.filter(subject => {
-      const filteringDays = (lesnTime: string): boolean => {
-        if (!lesnTime) return true;
-
-        if (selectedDays.length === 0) return true;
-
-        const match = lesnTime.match(/^([가-힣]+)(\d{1,2}):\d{2}-(\d{1,2}):\d{2}$/);
-        if (!match) return false;
-
-        const [_, dayStr] = match;
-        const days = dayStr.split('');
-        return selectedDays.some(d => days.includes(d));
-      };
-
-      const filteringDepartment = (subject: SubjectApiResponse): boolean => {
-        return !selectedDepartment || selectedDepartment === '' || selectedDepartment === subject.deptCd;
-      };
-
-      const filteringGrades = (subject: SubjectApiResponse): boolean => {
-        if (selectedGrades.length === 0) return true;
-        const sem = subject.studentYear;
-        if (selectedGrades.includes('전체')) return true;
-        if (selectedGrades.includes(1) && sem === '1') return true;
-        if (selectedGrades.includes(2) && sem === '2') return true;
-        if (selectedGrades.includes(3) && sem === '3') return true;
-        if (selectedGrades.includes(4) && sem === '4') return true;
-        return false;
-      };
-
-      const filteringSearchKeywords = (subject: SubjectApiResponse): boolean => {
-        if (!searchKeywords) return true;
-
-        const clearnSearchInput = searchKeywords.replace(/[^\w\sㄱ-ㅎㅏ-ㅣ가-힣]/g, '');
-        const disassembledSearchInput = disassemble(clearnSearchInput).toLowerCase();
-
-        const disassembledProfessorName = subject.professorName ? disassemble(subject.professorName).toLowerCase() : '';
-        const cleanSubjectName = subject.subjectName.replace(/[^\w\sㄱ-ㅎㅏ-ㅣ가-힣]/g, '');
-        const disassembledSubjectName = disassemble(cleanSubjectName).toLowerCase();
-
-        return (
-          disassembledProfessorName.includes(disassembledSearchInput) ||
-          disassembledSubjectName.includes(disassembledSearchInput)
-        );
-      };
-
-      return (
-        filteringGrades(subject) &&
-        filteringDays(subject.lesnTime) &&
-        filteringSearchKeywords(subject) &&
-        filteringDepartment(subject)
-      );
-    });
-  }, [subjects, selectedDepartment, selectedGrades, selectedDays, searchKeywords]);
+  const filteredData = useFilteringSubjects(subjects, searchKeywords);
 
   return (
     <div className="w-full h-screen md:basis-1/3 p-4 md:border-t-0 flex flex-col gap-3 bg-white shadow-md rounded-lg">
@@ -97,7 +33,11 @@ function ContentPanel() {
         <GradeFilter />
         <DayFilter />
       </div>
-      <button type="button" className="text-blue-500 cursor-pointer text-sm" onClick={handleCreateSchedule}>
+      <button
+        type="button"
+        className="text-blue-500 cursor-pointer text-sm"
+        onClick={() => openScheduleModal(initSchedule)}
+      >
         + 커스텀 일정 생성
       </button>
 

--- a/packages/client/src/components/contentPanel/ContentPanel.tsx
+++ b/packages/client/src/components/contentPanel/ContentPanel.tsx
@@ -9,6 +9,7 @@ import useScheduleModal from '@/hooks/useScheduleModal.ts';
 import { ScheduleAdapter } from '@/utils/timetable/adapter.ts';
 import FilterDelete from '@/components/contentPanel/filter/FilterDelete.tsx';
 import useFilteringSubjects from '@/hooks/useFilteringSubjects';
+import { useFilterScheduleStore } from '@/store/useFilterScheduleStore';
 
 const initSchedule = new ScheduleAdapter().toUiData();
 
@@ -16,7 +17,16 @@ function ContentPanel() {
   const { data: subjects = [], isPending } = useSubject();
   const [searchKeywords, setSearchKeywords] = useState('');
   const { openScheduleModal } = useScheduleModal();
-  const filteredData = useFilteringSubjects(subjects, searchKeywords);
+
+  const { selectedDays, selectedDepartment, selectedGrades } = useFilterScheduleStore();
+
+  const filteredData = useFilteringSubjects({
+    subjects,
+    searchKeywords,
+    selectedDays,
+    selectedDepartment,
+    selectedGrades,
+  });
 
   return (
     <div className="w-full h-screen md:basis-1/3 p-4 md:border-t-0 flex flex-col gap-3 bg-white shadow-md rounded-lg">

--- a/packages/client/src/components/contentPanel/bottomSheet/SearchBottomSheet.tsx
+++ b/packages/client/src/components/contentPanel/bottomSheet/SearchBottomSheet.tsx
@@ -3,14 +3,12 @@ import BottomSheet from './BottomSheet';
 import BottomSheetHeader from './BottomSheetHeader';
 import FilterSvg from '@/assets/filter.svg?react';
 import { FilteredSubjectCards } from '../subject/FilteredSubjectCards';
-import { useEffect, useState } from 'react';
-import { SubjectApiResponse } from '@/utils/types';
-import { disassemble } from 'es-hangul';
+import { useState } from 'react';
 import useSubject from '@/hooks/server/useSubject';
-import { useFilterScheduleStore } from '@/store/useFilterScheduleStore';
 import useScheduleModal from '@/hooks/useScheduleModal.ts';
 import { BottomSheetType } from '@/store/useBottomSheetStore';
 import { ScheduleAdapter } from '@/utils/timetable/adapter';
+import useFilteringSubjects from '@/hooks/useFilteringSubjects';
 
 interface ISearchBottomSheet {
   onCloseSearch: (bottomSheetType: BottomSheetType) => void;
@@ -18,84 +16,12 @@ interface ISearchBottomSheet {
 
 function SearchBottomSheet({ onCloseSearch }: ISearchBottomSheet) {
   const [searchKeywords, setSearchKeywords] = useState<string>('');
-  const [filteredData, setFilteredData] = useState<SubjectApiResponse[]>([]);
-
   const { data: subjects = [], isPending } = useSubject();
-  const { selectedDepartment, selectedGrades, selectedDays } = useFilterScheduleStore();
   const { openScheduleModal, cancelSchedule } = useScheduleModal();
 
+  const filteredData = useFilteringSubjects(subjects, searchKeywords);
+
   const initSchedule = new ScheduleAdapter().toUiData();
-
-  const handleCreateSchedule = () => {
-    openScheduleModal(initSchedule);
-  };
-
-  useEffect(() => {
-    if (!subjects) {
-      setFilteredData([]);
-      return;
-    }
-
-    const result = subjects.filter(subject => {
-      const filteringDays = (lesnTime: string): boolean => {
-        if (!lesnTime) return true;
-
-        if (selectedDays.length === 0) return true;
-
-        const match = lesnTime.match(/^([가-힣]+)(\d{1,2}):\d{2}-(\d{1,2}):\d{2}$/);
-        if (!match) return false;
-
-        const [_, dayStr] = match;
-        const days = dayStr.split('');
-        return selectedDays.some(d => days.includes(d));
-      };
-
-      const filteringDepartment = (subject: SubjectApiResponse): boolean => {
-        if (!selectedDepartment || selectedDepartment === '') return true;
-        if (selectedDepartment === subject.deptCd) return true;
-
-        return false;
-      };
-
-      const filteringGrades = (subject: SubjectApiResponse): boolean => {
-        if (selectedGrades.length === 0) return true;
-        const sem = subject.studentYear;
-        if (selectedGrades.includes('전체')) return true;
-        if (selectedGrades.includes(1) && sem === '1') return true;
-        if (selectedGrades.includes(2) && sem === '2') return true;
-        if (selectedGrades.includes(3) && sem === '3') return true;
-        if (selectedGrades.includes(4) && sem === '4') return true;
-        return false;
-      };
-
-      const filteringSearchKeywords = (subject: SubjectApiResponse): boolean => {
-        if (!searchKeywords) return true;
-
-        const clearnSearchInput = searchKeywords?.replace(/[^\w\sㄱ-ㅎㅏ-ㅣ가-힣]/g, '');
-        const disassembledSearchInput = disassemble(clearnSearchInput).toLowerCase();
-
-        const disassembledProfessorName = subject.professorName ? disassemble(subject.professorName).toLowerCase() : '';
-        const cleanSubjectName = subject.subjectName.replace(/[^\w\sㄱ-ㅎㅏ-ㅣ가-힣]/g, '');
-        const disassembledSubjectName = disassemble(cleanSubjectName).toLowerCase();
-
-        const matchesProfessor = disassembledProfessorName.includes(disassembledSearchInput);
-        const matchesSubject = disassembledSubjectName.includes(disassembledSearchInput);
-        return matchesProfessor || matchesSubject;
-      };
-
-      return (
-        filteringGrades(subject) &&
-        filteringDays(subject.lesnTime) &&
-        filteringSearchKeywords(subject) &&
-        filteringDepartment(subject)
-      );
-    });
-
-    if (result.length === 0) {
-      return;
-    }
-    setFilteredData(result);
-  }, [subjects, selectedDepartment, selectedGrades, selectedDays, searchKeywords]);
 
   return (
     <BottomSheet>
@@ -105,7 +31,7 @@ function SearchBottomSheet({ onCloseSearch }: ISearchBottomSheet) {
             title="과목검색"
             headerType="add"
             onClose={cancelSchedule}
-            onClick={handleCreateSchedule}
+            onClick={() => openScheduleModal(initSchedule)}
           />
 
           <div className="sticky px-2 top-0 bg-white z-10 flex items-center gap-2 py-3">

--- a/packages/client/src/components/contentPanel/bottomSheet/SearchBottomSheet.tsx
+++ b/packages/client/src/components/contentPanel/bottomSheet/SearchBottomSheet.tsx
@@ -9,6 +9,7 @@ import useScheduleModal from '@/hooks/useScheduleModal.ts';
 import { BottomSheetType } from '@/store/useBottomSheetStore';
 import { ScheduleAdapter } from '@/utils/timetable/adapter';
 import useFilteringSubjects from '@/hooks/useFilteringSubjects';
+import { useFilterScheduleStore } from '@/store/useFilterScheduleStore';
 
 interface ISearchBottomSheet {
   onCloseSearch: (bottomSheetType: BottomSheetType) => void;
@@ -18,8 +19,15 @@ function SearchBottomSheet({ onCloseSearch }: ISearchBottomSheet) {
   const [searchKeywords, setSearchKeywords] = useState<string>('');
   const { data: subjects = [], isPending } = useSubject();
   const { openScheduleModal, cancelSchedule } = useScheduleModal();
+  const { selectedDays, selectedDepartment, selectedGrades } = useFilterScheduleStore();
 
-  const filteredData = useFilteringSubjects(subjects, searchKeywords);
+  const filteredData = useFilteringSubjects({
+    subjects,
+    searchKeywords,
+    selectedDays,
+    selectedDepartment,
+    selectedGrades,
+  });
 
   const initSchedule = new ScheduleAdapter().toUiData();
 

--- a/packages/client/src/components/contentPanel/filter/CheckboxFilter.tsx
+++ b/packages/client/src/components/contentPanel/filter/CheckboxFilter.tsx
@@ -28,6 +28,14 @@ function CheckboxFilter<T extends string | number>({
   return (
     <Filtering label={label} selected={selected}>
       <>
+        <Checkbox
+          label={`전체${labelPrefix}`}
+          isChecked={selectedItems.length === options.length}
+          onChange={() => {
+            handleChangeCheckbox('전체' as T);
+          }}
+        />
+
         {options.map(item => (
           <Checkbox
             key={item}

--- a/packages/client/src/components/contentPanel/filter/CheckboxFilter.tsx
+++ b/packages/client/src/components/contentPanel/filter/CheckboxFilter.tsx
@@ -35,7 +35,6 @@ function CheckboxFilter<T extends string | number>({
             handleChangeCheckbox('전체' as T);
           }}
         />
-
         {options.map(item => (
           <Checkbox
             key={item}

--- a/packages/client/src/components/contentPanel/filter/DayFilter.tsx
+++ b/packages/client/src/components/contentPanel/filter/DayFilter.tsx
@@ -7,7 +7,12 @@ const DAYS: Day[] = ['월', '화', '수', '목', '금'];
 function DayFilter() {
   const { selectedDays, setFilterSchedule } = useFilterScheduleStore();
 
-  const handleChangeCheckbox = (item: Day) => {
+  const handleChangeCheckbox = (item: Day | '전체') => {
+    if (item === '전체') {
+      setFilterSchedule('selectedDays', selectedDays.length === DAYS.length ? [] : DAYS);
+      return;
+    }
+
     const isSelected = selectedDays.includes(item);
     const updatedDays = isSelected ? selectedDays.filter(day => day !== item) : [...selectedDays, item];
 

--- a/packages/client/src/components/contentPanel/filter/DepartmentFilter.tsx
+++ b/packages/client/src/components/contentPanel/filter/DepartmentFilter.tsx
@@ -11,7 +11,6 @@ function DepartmentFilter() {
   const [searchKeywords, setSearchKeywords] = useState('');
   const [category, setCategory] = useState<'전체' | '전공' | '교양'>('전공');
 
-
   const departmentsList = useMemo(
     () => [{ departmentName: '전체학과', departmentCode: '' }, ...(departments ?? [])],
     [departments],

--- a/packages/client/src/components/contentPanel/filter/GradeFilter.tsx
+++ b/packages/client/src/components/contentPanel/filter/GradeFilter.tsx
@@ -2,12 +2,17 @@ import { useFilterScheduleStore } from '@/store/useFilterScheduleStore';
 import CheckboxFilter from './CheckboxFilter';
 import { Grade } from '@/utils/types';
 
-const GRADE: Grade[] = ['전체', 1, 2, 3, 4];
+const GRADE: Grade[] = [1, 2, 3, 4];
 
 function GradeFilter() {
   const { selectedGrades, setFilterSchedule } = useFilterScheduleStore();
 
-  const handleChangeCheckbox = (item: Grade) => {
+  const handleChangeCheckbox = (item: Grade | '전체') => {
+    if (item === '전체') {
+      setFilterSchedule('selectedGrades', selectedGrades.length === GRADE.length ? [] : GRADE);
+      return;
+    }
+
     const isSelected = selectedGrades.includes(item);
     const updateGrades = isSelected ? selectedGrades.filter(grade => grade !== item) : [...selectedGrades, item];
     setFilterSchedule('selectedGrades', updateGrades);

--- a/packages/client/src/components/contentPanel/subject/FilteredSubjectCards.tsx
+++ b/packages/client/src/components/contentPanel/subject/FilteredSubjectCards.tsx
@@ -4,11 +4,11 @@ import useInfScroll from '@/hooks/useInfScroll'; // 수정된 useInfScroll impor
 import useScheduleModal from '@/hooks/useScheduleModal.ts';
 import { useScheduleState } from '@/store/useScheduleState';
 import { ScheduleAdapter, TimeslotAdapter } from '@/utils/timetable/adapter.ts';
-import { SubjectApiResponse } from '@/utils/types';
+import { Subject } from '@/utils/types';
 import { OfficialSchedule } from '@/hooks/server/useTimetableSchedules.ts';
 
 interface ISubjectCards {
-  subjects: SubjectApiResponse[];
+  subjects: Subject[];
   isPending?: boolean;
   expandToMax?: () => void;
 }
@@ -28,7 +28,7 @@ export function FilteredSubjectCards({ subjects, expandToMax, isPending = false 
     return <ZeroListError />;
   }
 
-  const handleCardClick = (subject: SubjectApiResponse) => {
+  const handleCardClick = (subject: Subject) => {
     if (selectedSubjectId === subject.subjectId) {
       cancelSchedule(undefined, false);
       return; // 이미 선택된 과목이면 아무 동작도 하지 않음
@@ -85,7 +85,7 @@ export function FilteredSubjectCards({ subjects, expandToMax, isPending = false 
 
 interface ISubjectCard {
   isActive?: boolean;
-  subject: SubjectApiResponse;
+  subject: Subject;
   onClick: () => void;
   forwardedRef?: React.Ref<HTMLDivElement>;
 }

--- a/packages/client/src/components/live/subjectTable/PinCard.tsx
+++ b/packages/client/src/components/live/subjectTable/PinCard.tsx
@@ -1,11 +1,11 @@
 import AlarmIcon from '@/components/svgs/AlarmIcon.tsx';
 import { usePinned, useAddPinned, useRemovePinned } from '@/store/usePinned.ts';
 import { getTimeDiffString } from '@/utils/stringFormats.ts';
-import { SubjectApiResponse, Wishes } from '@/utils/types.ts';
+import { Subject, Wishes } from '@/utils/types.ts';
 import { getSeatColor } from '@/utils/colors.ts';
 
 interface IPinCard {
-  subject: SubjectApiResponse | Wishes;
+  subject: Subject | Wishes;
   seats: number;
   queryTime?: string;
   disableSeat?: boolean;

--- a/packages/client/src/components/live/subjectTable/RealtimeCard.tsx
+++ b/packages/client/src/components/live/subjectTable/RealtimeCard.tsx
@@ -3,10 +3,10 @@ import useTick from '@/hooks/useTick.ts';
 import { useRemovePinned } from '@/store/usePinned.ts';
 import { getTimeDiffString } from '@/utils/stringFormats.ts';
 import { getSeatColor } from '@/utils/colors.ts';
-import { SubjectApiResponse, Wishes } from '@/utils/types.ts';
+import { Subject, Wishes } from '@/utils/types.ts';
 
 interface IPinCard {
-  subject: SubjectApiResponse | Wishes;
+  subject: Subject | Wishes;
   seats: number;
   queryTime?: string;
   disableSeat?: boolean;

--- a/packages/client/src/hooks/server/useLectures.ts
+++ b/packages/client/src/hooks/server/useLectures.ts
@@ -1,6 +1,6 @@
 import useSubject from '@/hooks/server/useSubject.ts';
 import useDepartments, { Department } from '@/hooks/server/useDepartments.ts';
-import { SubjectApiResponse } from '@/utils/types.ts';
+import { Subject } from '@/utils/types.ts';
 
 export interface Lecture {
   subjectId: number;
@@ -21,7 +21,7 @@ function useLectures() {
   const { data: subjects } = useSubject();
   const { data: departments } = useDepartments();
 
-  const getLectures = (subjects?: SubjectApiResponse[], departments?: Department[]): Lecture[] => {
+  const getLectures = (subjects?: Subject[], departments?: Department[]): Lecture[] => {
     if (!subjects || !departments) {
       return [];
     }

--- a/packages/client/src/hooks/server/useSubject.ts
+++ b/packages/client/src/hooks/server/useSubject.ts
@@ -1,9 +1,9 @@
 import { fetchJsonOnAPI } from '@/utils/api';
-import { SubjectApiResponse } from '@/utils/types';
+import { Subject } from '@/utils/types';
 import { useQuery } from '@tanstack/react-query';
 
 type SubjectResponse = {
-  subjectResponses: SubjectApiResponse[];
+  subjectResponses: Subject[];
 };
 
 const fetchSubjects = async () => {

--- a/packages/client/src/hooks/server/useTimetableSchedules.ts
+++ b/packages/client/src/hooks/server/useTimetableSchedules.ts
@@ -3,7 +3,7 @@ import useSubject from '@/hooks/server/useSubject.ts';
 import { ScheduleMutateType, useScheduleState } from '@/store/useScheduleState.ts';
 import { ScheduleAdapter, TimeslotAdapter } from '@/utils/timetable/adapter.ts';
 import { fetchDeleteJsonOnAPI, fetchJsonOnAPI, fetchOnAPI } from '@/utils/api.ts';
-import { Day, SubjectApiResponse } from '@/utils/types.ts';
+import { Day, Subject } from '@/utils/types.ts';
 import { timeSleep } from '@/utils/time.ts';
 
 export interface Timetable {
@@ -495,7 +495,7 @@ export function useDeleteSchedule(timetableId?: number) {
  * @param timetable
  * @param subjects
  */
-function toGeneralSchedules(timetable: Timetable, subjects?: SubjectApiResponse[]): GeneralSchedule[] {
+function toGeneralSchedules(timetable: Timetable, subjects?: Subject[]): GeneralSchedule[] {
   if (!timetable || !subjects) return [];
 
   const { schedules } = timetable;

--- a/packages/client/src/hooks/server/useWishes.ts
+++ b/packages/client/src/hooks/server/useWishes.ts
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import { SubjectApiResponse, Wishes } from '@/utils/types.ts';
+import { Subject, Wishes } from '@/utils/types.ts';
 import { fetchJsonOnPublic } from '@/utils/api.ts';
 import useSubject from '@/hooks/server/useSubject.ts';
 
@@ -22,19 +22,15 @@ function useWishes() {
   });
 }
 
-const joinSubjects = (wishes?: WishesApiResponse, subject?: SubjectApiResponse[]): Wishes[] => {
+const joinSubjects = (wishes?: WishesApiResponse, subject?: Subject[]): Wishes[] => {
   if (!wishes || !subject) return [];
 
-  return subject.map((subject: SubjectApiResponse) => {
+  return subject.map((subject: Subject) => {
     const wish = wishes.baskets.find(wish => wish.subjectId === subject.subjectId);
     return {
-      subjectId: subject.subjectId,
-      subjectName: subject.subjectName,
-      departmentName: subject.manageDeptNm,
+      ...subject,
       departmentCode: subject.deptCd,
-      subjectCode: subject.subjectCode,
-      classCode: subject.classCode,
-      professorName: subject.professorName,
+      departmentName: subject.manageDeptNm,
       totalCount: wish?.totalCount || 0,
     };
   });

--- a/packages/client/src/hooks/useFilteringSubjects.ts
+++ b/packages/client/src/hooks/useFilteringSubjects.ts
@@ -1,7 +1,7 @@
 import { filterDays, filterDepartment, filterGrades, filterSearchKeywords } from '@/utils/filtering/filterSubjects';
 import { Day, Grade, Subject } from '@/utils/types';
 
-interface IuseFilteringSubjects<T extends Subject> {
+interface IUseFilteringSubjects<T extends Subject> {
   subjects: T[];
   searchKeywords: string;
   selectedDays?: (Day | '전체')[];
@@ -18,8 +18,8 @@ function useFilteringSubjects<T extends Subject>({
   selectedDepartment,
   selectedGrades,
   isFavorite,
-  pickedFavorites,
-}: IuseFilteringSubjects<T>) {
+  pickedFavorites = () => false,
+}: IUseFilteringSubjects<T>) {
   if (!subjects || subjects.length === 0) return [];
 
   return subjects.filter(subject => {
@@ -28,10 +28,8 @@ function useFilteringSubjects<T extends Subject>({
     const filteredByDays = selectedDays ? filterDays(subject, selectedDays) : true;
     const filteredBySearchKeywords = filterSearchKeywords(subject, searchKeywords);
 
-    /**
-     * Wishes의 isFavorite
-     */
-    const filteredByIsFavorite = isFavorite ? (pickedFavorites ? pickedFavorites(subject.subjectId) : false) : true;
+    // Wishes의 isFavorite
+    const filteredByIsFavorite = !isFavorite || (isFavorite && pickedFavorites(subject.subjectId));
 
     return (
       filteredByDepartment && filteredByGrades && filteredByDays && filteredBySearchKeywords && filteredByIsFavorite

--- a/packages/client/src/hooks/useFilteringSubjects.ts
+++ b/packages/client/src/hooks/useFilteringSubjects.ts
@@ -1,20 +1,44 @@
-import { useFilterScheduleStore } from '@/store/useFilterScheduleStore';
 import { filterDays, filterDepartment, filterGrades, filterSearchKeywords } from '@/utils/filtering/filterSubjects';
-import { SubjectApiResponse } from '@/utils/types';
+import { Day, Grade, Subject } from '@/utils/types';
 
-function useFilteringSubjects(subjects: SubjectApiResponse[], searchKeywords: string) {
-  const { selectedDays, selectedDepartment, selectedGrades } = useFilterScheduleStore();
+interface IuseFilteringSubjects<T extends Subject> {
+  subjects: T[];
+  searchKeywords: string;
+  selectedDays?: (Day | '전체')[];
+  selectedGrades?: (Grade | '전체')[];
+  isFavorite?: boolean;
+  selectedDepartment: string;
+  pickedFavorites?: (id: number) => boolean;
+}
 
-  const filteredSubjects = subjects.filter(subject => {
+function useFilteringSubjects<T extends Subject>({
+  subjects,
+  searchKeywords,
+  selectedDays,
+  selectedDepartment,
+  selectedGrades,
+  isFavorite,
+  pickedFavorites,
+}: IuseFilteringSubjects<T>) {
+  if (!subjects || subjects.length === 0) return [];
+
+  return subjects.filter(subject => {
     const filteredByDepartment = filterDepartment(subject, selectedDepartment);
-    const filteredByGrades = filterGrades(subject, selectedGrades);
-    const filteredByDays = filterDays(subject, selectedDays);
+    const filteredByGrades = selectedGrades ? filterGrades(subject, selectedGrades) : true;
+    const filteredByDays = selectedDays ? filterDays(subject, selectedDays) : true;
     const filteredBySearchKeywords = filterSearchKeywords(subject, searchKeywords);
 
-    return filteredByDepartment && filteredByGrades && filteredByDays && filteredBySearchKeywords;
-  });
+    /**
+     * Wishes의 isFavorite
+     */
+    const filteredByIsFavorite = isFavorite ? (pickedFavorites ? pickedFavorites(subject.subjectId) : false) : true;
 
-  return filteredSubjects;
+    return (
+      filteredByDepartment && filteredByGrades && filteredByDays && filteredBySearchKeywords && filteredByIsFavorite
+    );
+
+    // TODO: pin 필터링 로직 추가
+  });
 }
 
 export default useFilteringSubjects;

--- a/packages/client/src/hooks/useFilteringSubjects.ts
+++ b/packages/client/src/hooks/useFilteringSubjects.ts
@@ -1,0 +1,20 @@
+import { useFilterScheduleStore } from '@/store/useFilterScheduleStore';
+import { filterDays, filterDepartment, filterGrades, filterSearchKeywords } from '@/utils/filtering/filterSubjects';
+import { SubjectApiResponse } from '@/utils/types';
+
+function useFilteringSubjects(subjects: SubjectApiResponse[], searchKeywords: string) {
+  const { selectedDays, selectedDepartment, selectedGrades } = useFilterScheduleStore();
+
+  const filteredSubjects = subjects.filter(subject => {
+    const filteredByDepartment = filterDepartment(subject, selectedDepartment);
+    const filteredByGrades = filterGrades(subject, selectedGrades);
+    const filteredByDays = filterDays(subject, selectedDays);
+    const filteredBySearchKeywords = filterSearchKeywords(subject, searchKeywords);
+
+    return filteredByDepartment && filteredByGrades && filteredByDays && filteredBySearchKeywords;
+  });
+
+  return filteredSubjects;
+}
+
+export default useFilteringSubjects;

--- a/packages/client/src/hooks/useInfScroll.ts
+++ b/packages/client/src/hooks/useInfScroll.ts
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import { SubjectApiResponse, Wishes } from '@/utils/types.ts';
+import { Subject, Wishes } from '@/utils/types.ts';
 import { Lecture } from './server/useLectures';
 
 const PAGE_SIZE = 45;
@@ -7,7 +7,7 @@ const PAGE_SIZE = 45;
 type UseInfiniteScrollMode = 'ref' | 'selector';
 
 function useInfScroll(
-  data: Wishes[] | SubjectApiResponse[] | Lecture[],
+  data: Wishes[] | Subject[] | Lecture[],
   mode: UseInfiniteScrollMode = 'ref',
   selector: string = '.load-more-trigger',
 ) {

--- a/packages/client/src/pages/wishlist/WishTable.tsx
+++ b/packages/client/src/pages/wishlist/WishTable.tsx
@@ -1,32 +1,23 @@
 import { Helmet } from 'react-helmet';
-import { useState, useEffect } from 'react';
 import useWishes from '@/hooks/server/useWishes.ts';
+import useFilteringSubjects from '@/hooks/useFilteringSubjects';
 import Table from '@/components/wishTable/Table.tsx';
 import Searches from '@/components/live/Searches.tsx';
-import { Wishes } from '@/utils/types.ts';
 import useFavorites from '@/store/useFavorites.ts';
 import useWishSearchStore from '@/store/useWishSearchStore.ts';
-import useFilteringSubjects from '@/hooks/useFilteringSubjects';
 
 function WishTable() {
   const filterParams = useWishSearchStore(state => state.searchParams);
-  const [filteredData, setFilteredData] = useState<Wishes[]>([]);
   const pickedFavorites = useFavorites(state => state.isFavorite);
   const { data: subjects, isPending } = useWishes();
 
-  useEffect(() => {
-    if (!subjects) return;
-
-    setFilteredData(
-      useFilteringSubjects({
-        subjects,
-        pickedFavorites,
-        searchKeywords: filterParams.searchInput,
-        selectedDepartment: filterParams.selectedDepartment,
-        isFavorite: filterParams.isFavorite,
-      }),
-    );
-  }, [filterParams, subjects]);
+  const filteredData = useFilteringSubjects({
+    subjects: subjects ?? [],
+    pickedFavorites,
+    searchKeywords: filterParams.searchInput,
+    selectedDepartment: filterParams.selectedDepartment,
+    isFavorite: filterParams.isFavorite,
+  });
 
   return (
     <>

--- a/packages/client/src/store/useFilterScheduleStore.ts
+++ b/packages/client/src/store/useFilterScheduleStore.ts
@@ -10,7 +10,7 @@ interface TimeRange {
 
 interface FilterState {
   selectedDepartment: string;
-  selectedGrades: Grade[];
+  selectedGrades: (Grade | '전체')[];
   isMajor?: boolean;
   selectedDays: Day[];
   selectedTimeRange: TimeRange;

--- a/packages/client/src/store/useSearchSubject.ts
+++ b/packages/client/src/store/useSearchSubject.ts
@@ -1,4 +1,4 @@
-import { SubjectApiResponse } from '@/utils/types.ts';
+import { Subject } from '@/utils/types.ts';
 import { useQuery } from '@tanstack/react-query';
 import { fetchJsonOnAPI } from '@/utils/api.ts';
 
@@ -11,7 +11,7 @@ export function useSearchSubject(searchOption: SubjectOption) {
 }
 
 interface SubjectResponse {
-  subjectResponses: SubjectApiResponse[];
+  subjectResponses: Subject[];
 }
 
 interface SubjectOption {

--- a/packages/client/src/utils/filtering/filterSubjects.ts
+++ b/packages/client/src/utils/filtering/filterSubjects.ts
@@ -1,7 +1,7 @@
 import { disassemble } from 'es-hangul';
-import { Day, Grade, SubjectApiResponse } from '../types';
+import { Day, Grade, Subject, Wishes } from '../types';
 
-export function filterDays(subject: SubjectApiResponse, selectedDays: (Day | '전체')[]) {
+export function filterDays(subject: Wishes | Subject, selectedDays: (Day | '전체')[]) {
   if (!subject.lesnTime) {
     return false;
   }
@@ -11,7 +11,6 @@ export function filterDays(subject: SubjectApiResponse, selectedDays: (Day | '�
   if (!timeMatchResult) {
     return false;
   }
-
   if (selectedDays.includes('전체') || selectedDays.length === 0) {
     return true;
   }
@@ -20,7 +19,7 @@ export function filterDays(subject: SubjectApiResponse, selectedDays: (Day | '�
   return selectedDays.some(selectedDay => lessonDays.includes(selectedDay));
 }
 
-export function filterGrades(subject: SubjectApiResponse, selectedGrades: (Grade | '전체')[]) {
+export function filterGrades(subject: Wishes | Subject, selectedGrades: (Grade | '전체')[]) {
   const subjectGrade = Number(subject.studentYear);
 
   if (!subjectGrade) {
@@ -34,17 +33,17 @@ export function filterGrades(subject: SubjectApiResponse, selectedGrades: (Grade
   return selectedGrades.includes(subjectGrade as Grade);
 }
 
-export function filterDepartment(subject: SubjectApiResponse, selectedDepartment: string) {
+export function filterDepartment(subject: Wishes | Subject, selectedDepartment: string) {
   return !selectedDepartment || selectedDepartment === '' || selectedDepartment === subject.deptCd;
 }
 
-export function filterSearchKeywords(subject: SubjectApiResponse, searchKeywords: string) {
+export function filterSearchKeywords(subject: Wishes | Subject, searchKeywords: string) {
   if (!searchKeywords) {
     return true;
   }
 
-  const clearnSearchInput = searchKeywords.replace(/[^\w\sㄱ-ㅎㅏ-ㅣ가-힣]/g, '');
-  const disassembledSearchInput = disassemble(clearnSearchInput).toLowerCase();
+  const cleanSearchInput = searchKeywords.replace(/[^\w\sㄱ-ㅎㅏ-ㅣ가-힣]/g, '');
+  const disassembledSearchInput = disassemble(cleanSearchInput).toLowerCase();
 
   const disassembledProfessorName = subject.professorName ? disassemble(subject.professorName).toLowerCase() : '';
   const cleanSubjectName = subject.subjectName.replace(/[^\w\sㄱ-ㅎㅏ-ㅣ가-힣]/g, '');

--- a/packages/client/src/utils/filtering/filterSubjects.ts
+++ b/packages/client/src/utils/filtering/filterSubjects.ts
@@ -6,7 +6,7 @@ export function filterDays(subject: Wishes | Subject, selectedDays: (Day | '전�
     return false;
   }
 
-  const timeMatchResult = subject.lesnTime.match(/^([가-힣]+)/);
+  const timeMatchResult = RegExp(/^([가-힣]+)/).exec(subject.lesnTime);
 
   if (!timeMatchResult) {
     return false;

--- a/packages/client/src/utils/filtering/filterSubjects.ts
+++ b/packages/client/src/utils/filtering/filterSubjects.ts
@@ -1,0 +1,57 @@
+import { disassemble } from 'es-hangul';
+import { Day, Grade, SubjectApiResponse } from '../types';
+
+export function filterDays(subject: SubjectApiResponse, selectedDays: (Day | '전체')[]) {
+  if (!subject.lesnTime) {
+    return false;
+  }
+
+  const timeMatchResult = subject.lesnTime.match(/^([가-힣]+)/);
+
+  if (!timeMatchResult) {
+    return false;
+  }
+
+  if (selectedDays.includes('전체') || selectedDays.length === 0) {
+    return true;
+  }
+
+  const lessonDays = timeMatchResult[1].split('');
+  return selectedDays.some(selectedDay => lessonDays.includes(selectedDay));
+}
+
+export function filterGrades(subject: SubjectApiResponse, selectedGrades: (Grade | '전체')[]) {
+  const subjectGrade = Number(subject.studentYear);
+
+  if (!subjectGrade) {
+    return false;
+  }
+
+  if (selectedGrades.includes('전체') || selectedGrades.length === 0) {
+    return true;
+  }
+
+  return selectedGrades.includes(subjectGrade as Grade);
+}
+
+export function filterDepartment(subject: SubjectApiResponse, selectedDepartment: string) {
+  return !selectedDepartment || selectedDepartment === '' || selectedDepartment === subject.deptCd;
+}
+
+export function filterSearchKeywords(subject: SubjectApiResponse, searchKeywords: string) {
+  if (!searchKeywords) {
+    return true;
+  }
+
+  const clearnSearchInput = searchKeywords.replace(/[^\w\sㄱ-ㅎㅏ-ㅣ가-힣]/g, '');
+  const disassembledSearchInput = disassemble(clearnSearchInput).toLowerCase();
+
+  const disassembledProfessorName = subject.professorName ? disassemble(subject.professorName).toLowerCase() : '';
+  const cleanSubjectName = subject.subjectName.replace(/[^\w\sㄱ-ㅎㅏ-ㅣ가-힣]/g, '');
+  const disassembledSubjectName = disassemble(cleanSubjectName).toLowerCase();
+
+  return (
+    disassembledProfessorName.includes(disassembledSearchInput) ||
+    disassembledSubjectName.includes(disassembledSearchInput)
+  );
+}

--- a/packages/client/src/utils/timetable/adapter.ts
+++ b/packages/client/src/utils/timetable/adapter.ts
@@ -1,6 +1,6 @@
 import { CustomSchedule, OfficialSchedule, GeneralSchedule, TimeSlot } from '@/hooks/server/useTimetableSchedules.ts';
 import { ROW_HEIGHT } from '@/components/timetable/TimetableComponent.tsx';
-import { Day, SubjectApiResponse } from '@/utils/types.ts';
+import { Day, Subject } from '@/utils/types.ts';
 
 interface ApiUiAdapter<T, U> {
   data: U; // Initial data
@@ -21,7 +21,7 @@ export class ScheduleAdapter implements ApiUiAdapter<ScheduleApiResponse, Genera
    * @param data - Schedule 또는 ScheduleApiResponse 타입의 데이터, 빈 경우 기본값으로 초기화됩니다.
    * @param subjects - data가 ScheduleApiResponse 인 경우, Wishes 배열이 필요합니다.
    */
-  constructor(data?: GeneralSchedule | ScheduleApiResponse, subjects?: SubjectApiResponse | SubjectApiResponse[]) {
+  constructor(data?: GeneralSchedule | ScheduleApiResponse, subjects?: Subject | Subject[]) {
     if (!data) {
       this.data = this.#toDefaultData();
       return;
@@ -51,15 +51,13 @@ export class ScheduleAdapter implements ApiUiAdapter<ScheduleApiResponse, Genera
     };
   }
 
-  #apiToUiData(schedule: ScheduleApiResponse, subjects?: SubjectApiResponse | SubjectApiResponse[]): GeneralSchedule {
+  #apiToUiData(schedule: ScheduleApiResponse, subjects?: Subject | Subject[]): GeneralSchedule {
     if (!subjects) {
       throw new TypeError('Subjects must be provided for API to UI conversion');
     }
 
     const subj =
-      subjects instanceof Array
-        ? subjects.find(s => s.subjectId === schedule.subjectId)
-        : (subjects as SubjectApiResponse);
+      subjects instanceof Array ? subjects.find(s => s.subjectId === schedule.subjectId) : (subjects as Subject);
 
     return {
       scheduleId: schedule.scheduleId,

--- a/packages/client/src/utils/timetable/adapter.ts
+++ b/packages/client/src/utils/timetable/adapter.ts
@@ -8,9 +8,6 @@ interface ApiUiAdapter<T, U> {
   toUiData: () => U;
 }
 
-// Todo: Implement TimetableAdapter
-// export class TimetableAdapter implements ApiUiAdapter<Timetable> {}
-
 type ScheduleApiResponse = OfficialSchedule | CustomSchedule;
 
 export class ScheduleAdapter implements ApiUiAdapter<ScheduleApiResponse, GeneralSchedule> {
@@ -56,8 +53,7 @@ export class ScheduleAdapter implements ApiUiAdapter<ScheduleApiResponse, Genera
       throw new TypeError('Subjects must be provided for API to UI conversion');
     }
 
-    const subj =
-      subjects instanceof Array ? subjects.find(s => s.subjectId === schedule.subjectId) : (subjects as Subject);
+    const subj = subjects instanceof Array ? subjects.find(s => s.subjectId === schedule.subjectId) : subjects;
 
     return {
       scheduleId: schedule.scheduleId,

--- a/packages/client/src/utils/types.ts
+++ b/packages/client/src/utils/types.ts
@@ -69,12 +69,3 @@ export interface DepartmentType {
 export type Grade = 1 | 2 | 3 | 4;
 export type Day = '월' | '화' | '수' | '목' | '금' | '토' | '일';
 export const DAYS: Day[] = ['월', '화', '수', '목', '금', '토', '일'];
-
-export interface FilterableSubject {
-  subjectId: number;
-  subjectName: string;
-  departmentCode: string;
-  subjectCode: string;
-  classCode: string;
-  professorName?: string | null;
-}

--- a/packages/client/src/utils/types.ts
+++ b/packages/client/src/utils/types.ts
@@ -71,6 +71,6 @@ export interface DepartmentType {
   departmentName: string;
 }
 
-export type Grade = 1 | 2 | 3 | 4 | '전체';
+export type Grade = 1 | 2 | 3 | 4;
 export type Day = '월' | '화' | '수' | '목' | '금' | '토' | '일';
 export const DAYS: Day[] = ['월', '화', '수', '목', '금', '토', '일'];

--- a/packages/client/src/utils/types.ts
+++ b/packages/client/src/utils/types.ts
@@ -14,14 +14,9 @@ export interface Wishlist {
   baskets: Wishes[];
 }
 
-export interface Wishes {
-  subjectId: number;
-  subjectName: string;
-  departmentName: string;
+export interface Wishes extends Subject {
   departmentCode: string;
-  subjectCode: string;
-  classCode: string;
-  professorName: string | null;
+  departmentName: string;
   totalCount: number;
 }
 
@@ -46,7 +41,7 @@ export interface SimulationSubject {
   tm_num: string;
 }
 
-export interface SubjectApiResponse {
+export interface Subject {
   subjectId: number; // 과목 ID
   subjectName: string; // 과목명
   subjectCode: string; // 과목 코드
@@ -74,3 +69,12 @@ export interface DepartmentType {
 export type Grade = 1 | 2 | 3 | 4;
 export type Day = '월' | '화' | '수' | '목' | '금' | '토' | '일';
 export const DAYS: Day[] = ['월', '화', '수', '목', '금', '토', '일'];
+
+export interface FilterableSubject {
+  subjectId: number;
+  subjectName: string;
+  departmentCode: string;
+  subjectCode: string;
+  classCode: string;
+  professorName?: string | null;
+}


### PR DESCRIPTION
## 작업 내용
필터링 훅 구현 및 리팩토링을 진행하였습니다. 
기존에 하나의 컴포넌트에서 관리하던 함수들을 따로 utils로 빼고, 
subject와 filtering된 상태들로 필터링된 subjects를 관리하는 훅을 만들었습니다.


## 변경 사항 및 리뷰 포인트

- SubjectApiResponse 타입 -> Subject 타입으로 변경: 추후 API Response 필드의 변경이 있을 경우 다시 SubejctApiResponse 타입 정의할 예정입니다. 
- Wishes, Subject의 필터링을 하나로 통합했습니다. 
- Wishes 응답 값을 Subject로 join했습니다. 