### PR TITLE
실시간 페이지 UI 수정

### DIFF
--- a/packages/client/src/assets/eye-delete-gray.svg
+++ b/packages/client/src/assets/eye-delete-gray.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.875 18.825A10.05 10.05 0 0112 19c-4.477 0-8.268-2.943-9.542-7a9.957 9.957 0 012.043-3.36m3.237-2.347A9.956 9.956 0 0112 5c4.478 0 8.268 2.943 9.542 7a9.954 9.954 0 01-4.043 5.132M15 12a3 3 0 11-6 0 3 3 0 016 0z"/>
+    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 3l18 18" />
+</svg>

--- a/packages/client/src/assets/eye-gray.svg
+++ b/packages/client/src/assets/eye-gray.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/>
+    <path stroke-linecap="round" stroke-linejoin="round" stroke-width='2' d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"/>
+</svg>

--- a/packages/client/src/components/live/PinnedCourses.tsx
+++ b/packages/client/src/components/live/PinnedCourses.tsx
@@ -11,11 +11,13 @@ import useNotification from '@/hooks/useNotification.ts';
 import AlarmBlueIcon from '@/assets/alarm-blue.svg?react';
 import AlarmDisabledIcon from '@/assets/alarm-disabled.svg?react';
 import SettingSvg from '@/assets/settings.svg?react';
+import ReloadSvg from '@/assets/reload-blue.svg?react';
 import AlarmAddButton from './AlarmAddButton.tsx';
 
 const PinnedCourses = () => {
   const [isAlarmSettingOpen, setIsAlarmSettingOpen] = useState(false);
   const { isAlarm, changeAlarm } = useNotification();
+  const { isError, refetch } = useSseData(SSEType.PINNED);
 
   return (
     <>
@@ -32,6 +34,16 @@ const PinnedCourses = () => {
             </Tooltip>
           </div>
           <div className="flex gap-1 items-center">
+            {isError && (
+              <button
+                className="p-2 rounded-full hover:bg-blue-100"
+                aria-label="알림 재연결"
+                title="알림 재연결"
+                onClick={refetch}
+              >
+                <ReloadSvg className="w-5 h-5" />
+              </button>
+            )}
             <button
               className="p-2 rounded-full hover:bg-blue-100"
               aria-label="알림 설정"

--- a/packages/client/src/components/live/RealtimeTable.tsx
+++ b/packages/client/src/components/live/RealtimeTable.tsx
@@ -9,6 +9,7 @@ import { SSEType } from '@/hooks/useSSEManager.ts';
 import useSSESeats, { SseSubject } from '@/hooks/server/useSSESeats.ts';
 import { getTimeDiffString } from '@/utils/stringFormats.ts';
 import { getSeatColor } from '@/utils/colors.ts';
+import TableColorInfo from '@/components/wishTable/TableColorInfo.tsx';
 
 interface IRealtimeTable {
   title: string;
@@ -53,6 +54,8 @@ const RealtimeTable = ({ title = '교양과목' }: Readonly<IRealtimeTable>) => 
           </tbody>
         </table>
       </div>
+
+      <TableColorInfo />
     </CardWrap>
   );
 };

--- a/packages/client/src/components/live/RealtimeTable.tsx
+++ b/packages/client/src/components/live/RealtimeTable.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { TransitionGroup, CSSTransition } from 'react-transition-group';
 import CardWrap from '@/components/CardWrap.tsx';
-import Tooltip from '@/components/common/Tooltip.tsx';
 import SkeletonRows from '@/components/live/skeletons/SkeletonRows.tsx';
 import NetworkError from '@/components/live/errors/NetworkError.tsx';
 import ZeroListError from '@/components/live/errors/ZeroListError.tsx';
@@ -27,15 +26,15 @@ const TableHeadTitles = [
 const RealtimeTable = ({ title = '교양과목' }: Readonly<IRealtimeTable>) => {
   return (
     <CardWrap>
-      <div className="flex justify-between items-center mb-4">
+      <div className="flex justify-between items-center">
         <div className="flex items-center justify-center gap-2 mb-4">
-          <h2 className="font-bold text-lg p-2">{title} 실시간</h2>
-          <Tooltip>
-            <p className="text-sm">
-              <b className="text-green-500">전체 과목 실시간 여석</b>을 <br />
-              제공하고 있어요
-            </p>
-          </Tooltip>
+          <h2 className="font-bold text-lg">{title} 실시간</h2>
+          {/*<Tooltip>*/}
+          {/*  <p className="text-sm">*/}
+          {/*    <b className="text-green-500">전체 과목 실시간 여석</b>을 <br />*/}
+          {/*    제공하고 있어요*/}
+          {/*  </p>*/}
+          {/*</Tooltip>*/}
         </div>
       </div>
       <div className="overflow-x-auto">

--- a/packages/client/src/components/live/subjectTable/DraggableList.tsx
+++ b/packages/client/src/components/live/subjectTable/DraggableList.tsx
@@ -1,0 +1,181 @@
+import React, { useRef, useState, useEffect } from 'react';
+import EyeGray from '@/assets/eye-gray.svg?react';
+import EyeDeleteGray from '@/assets/eye-delete-gray.svg?react';
+
+interface Item {
+  title: string;
+  visible: boolean;
+}
+
+type Props<T extends Item> = {
+  initialItems: T[];
+  onChange?: (items: T[]) => void;
+};
+
+export default function DraggableList<T extends Item>({ initialItems, onChange }: Props<T>) {
+  const [items, setItems] = useState(initialItems);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  // const draggingRef = useRef<{ index: number; height: number } | null>(null);
+  const [draggingIndex /*setDraggingIndex*/] = useState<number | null>(null);
+  const [draggingStyle /*setDraggingStyle*/] = useState<React.CSSProperties | null>(null);
+  const positionsRef = useRef<number[]>([]); // center Y positions of items
+
+  useEffect(() => {
+    onChange?.(items);
+  }, [items, onChange]);
+
+  useEffect(() => {
+    // recalc item positions whenever items change
+    recalcPositions();
+    // window resize -> recalc
+    const ro = new ResizeObserver(recalcPositions);
+    if (containerRef.current) ro.observe(containerRef.current);
+    window.addEventListener('scroll', recalcPositions, true);
+    return () => {
+      ro.disconnect();
+      window.removeEventListener('scroll', recalcPositions, true);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [items]);
+
+  function onVisibleChange(index: number) {
+    setItems(prev => {
+      const next = prev.slice();
+      next[index] = { ...next[index], visible: !next[index].visible };
+      return next;
+    });
+    // recalc positions after visibility change
+    requestAnimationFrame(recalcPositions);
+  }
+
+  function recalcPositions() {
+    const container = containerRef.current;
+    if (!container) return;
+    const els = Array.from(container.children) as HTMLElement[];
+    positionsRef.current = els.map(el => {
+      const r = el.getBoundingClientRect();
+      return r.top + r.height / 2 + window.scrollY;
+    });
+  }
+
+  // function startDrag(e: React.PointerEvent, index: number) {
+  //   (e.target as Element).setPointerCapture(e.pointerId);
+  //   const target = (e.target as HTMLElement).closest('.draggable-item') as HTMLElement;
+  //   if (!target) return;
+  //   const rect = target.getBoundingClientRect();
+  //   draggingRef.current = { index, height: rect.height };
+  //   setDraggingIndex(index);
+  //   setDraggingStyle({
+  //     width: rect.width,
+  //     left: rect.left,
+  //     top: rect.top + window.scrollY,
+  //     position: 'absolute',
+  //     zIndex: 50,
+  //     pointerEvents: 'none',
+  //   });
+  //
+  //   // listen globally for move/up
+  //   window.addEventListener('pointermove', onPointerMove);
+  //   window.addEventListener('pointerup', onPointerUp);
+  // }
+
+  // function onPointerMove(e: PointerEvent) {
+  //   if (draggingRef.current == null) return;
+  //   const y = e.clientY + window.scrollY;
+  //   setDraggingStyle(s => ({ ...(s || {}), top: y - draggingRef.current!.height / 2 }));
+  //
+  //   // find hovered index by comparing center positions
+  //   const centers = positionsRef.current;
+  //   let hoverIndex = centers.findIndex(c => y < c);
+  //   if (hoverIndex === -1) hoverIndex = centers.length - 1;
+  //   const from = draggingRef.current.index;
+  //   const to = hoverIndex;
+  //   if (to !== from) {
+  //     setItems(prev => {
+  //       const next = prev.slice();
+  //       const [moved] = next.splice(from, 1);
+  //       next.splice(to, 0, moved);
+  //       // update draggingRef index
+  //       draggingRef.current = { ...draggingRef.current!, index: to };
+  //       // update stored positions after DOM updates (next tick)
+  //       requestAnimationFrame(recalcPositions);
+  //       return next;
+  //     });
+  //   }
+  // }
+
+  // function onPointerUp(/*e: PointerEvent*/) {
+  //   window.removeEventListener('pointermove', onPointerMove);
+  //   window.removeEventListener('pointerup', onPointerUp);
+  //   draggingRef.current = null;
+  //   setDraggingIndex(null);
+  //   setDraggingStyle(null);
+  // }
+
+  // keyboard reorder support: move item up/down with Ctrl+ArrowUp/Down when focused
+  function onKey(e: React.KeyboardEvent, index: number) {
+    if (e.ctrlKey && (e.key === 'ArrowUp' || e.key === 'ArrowDown')) {
+      e.preventDefault();
+      setItems(prev => {
+        const next = prev.slice();
+        const to = e.key === 'ArrowUp' ? Math.max(0, index - 1) : Math.min(next.length - 1, index + 1);
+        if (to === index) return prev;
+        const [moved] = next.splice(index, 1);
+        next.splice(to, 0, moved);
+        requestAnimationFrame(recalcPositions);
+        return next;
+      });
+    }
+  }
+
+  return (
+    <>
+      <div ref={containerRef} className="bg-white divide-y divide-gray-100">
+        {items.map((it, i) => (
+          <div
+            key={it + '-' + i}
+            className={`draggable-item flex items-center justify-between rounded-md px-2 transition-transform duration-200 ease`}
+            tabIndex={0}
+            onKeyDown={e => onKey(e, i)}
+          >
+            <div className="flex items-center gap-2">
+              {/*<button*/}
+              {/*  className="p-1 text-gray-500 hover:text-gray-700"*/}
+              {/*  onPointerDown={e => startDrag(e, i)}*/}
+              {/*  aria-label={`Drag ${it.title}`}*/}
+              {/*  title="드래그 시작"*/}
+              {/*>*/}
+              {/*  ⠿*/}
+              {/*</button>*/}
+              <button
+                className="p-1 text-gray-500 hover:text-gray-700"
+                aria-label={it.visible ? '숨기기' : '보이기'}
+                title={it.visible ? '숨기기' : '보이기'}
+                onClick={() => onVisibleChange(i)}
+              >
+                {it.visible ? <EyeGray className="w-4 h-4" /> : <EyeDeleteGray className="w-4 h-4" />}
+              </button>
+            </div>
+            <div className="font-medium">{it.title}</div>
+          </div>
+        ))}
+      </div>
+
+      {/* floating drag preview */}
+      {draggingStyle && (
+        <div
+          style={draggingStyle}
+          className="pointer-events-none bg-blue-50 rounded-md shadow-lg w-full max-w-lg m-auto px-2"
+        >
+          <div className="flex items-center justify-between">
+            <span className="p-1 text-gray-700">⠿</span>
+            <div className="font-medium">{items[draggingIndex ?? 0].title}</div>
+          </div>
+        </div>
+      )}
+
+      <div className="mt-4 text-sm text-gray-500">Tip: 보이는 테이블의 정보를 수정할 수 있습니다.</div>
+      {/*<div className="mt-4 text-sm text-gray-500">Tip: 항목을 선택한 뒤 Ctrl + ↑/↓ 로 키보드 이동도 가능합니다.</div>*/}
+    </>
+  );
+}

--- a/packages/client/src/components/wishTable/TableColorInfo.tsx
+++ b/packages/client/src/components/wishTable/TableColorInfo.tsx
@@ -1,0 +1,16 @@
+function TableColorInfo() {
+  return (
+    <div className="flex justify-end items-center mt-2 text-xs text-gray-500">
+      <span className="flex items-center gap-2">
+        <span className="block w-4 h-4 rounded bg-green-200 ml-1" aria-label="초록색 " />
+        영어로 진행되는 과목
+      </span>
+      <span className="flex items-center gap-2 ml-4">
+        <span className="block w-4 h-4 rounded bg-gray-200 ml-1" aria-label="회색 " />
+        삭제된 과목
+      </span>
+    </div>
+  );
+}
+
+export default TableColorInfo;

--- a/packages/client/src/hooks/server/useSSESeats.ts
+++ b/packages/client/src/hooks/server/useSSESeats.ts
@@ -1,0 +1,36 @@
+import { SSEType, useSseData } from '@/hooks/useSSEManager.ts';
+import useSubject, { InitSubject } from '@/hooks/server/useSubject.ts';
+import { Subject } from '@/utils/types.ts';
+
+export interface SseSubject extends Subject {
+  code?: string;
+  name?: string;
+  professor?: string | null;
+  seat?: number;
+  queryTime?: string;
+}
+
+// SSE 데이터와, subject 를 결합해주는 훅
+function useSSESeats(sseType: SSEType) {
+  const { data: subjectData } = useSubject();
+  const { data: subjectIds, ...rest } = useSseData(sseType);
+
+  const tableData = subjectIds?.map(pinSeats => {
+    const { subjectId, seatCount, queryTime } = pinSeats;
+    const subject = subjectData?.find(subject => subject.subjectId === subjectId) || InitSubject;
+    const { subjectName, subjectCode, classCode, professorName } = subject;
+
+    return {
+      ...subject,
+      code: `${subjectCode}-${classCode}`,
+      name: subjectName,
+      professor: professorName,
+      seat: seatCount,
+      queryTime,
+    };
+  }) as SseSubject[] | undefined;
+
+  return { data: tableData, ...rest };
+}
+
+export default useSSESeats;

--- a/packages/client/src/hooks/useNotification.ts
+++ b/packages/client/src/hooks/useNotification.ts
@@ -39,7 +39,7 @@ export function requestNotificationPermission(callback?: (permission: Notificati
   }
 }
 
-function showNotification(message: string, tag?: string) {
+export function showNotification(message: string, tag?: string) {
   const isAlarmActivated = useAlarmSettings.getState().isAlarmActivated;
 
   if (isAlarmActivated)

--- a/packages/client/src/hooks/useSSEManager.ts
+++ b/packages/client/src/hooks/useSSEManager.ts
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import { QueryClient, useQuery, useQueryClient } from '@tanstack/react-query';
-import { onChangePinned } from '@/hooks/useNotification.ts';
+import { onChangePinned, showNotification } from '@/hooks/useNotification.ts';
 import { NonMajorSeats, PinnedSeats } from '@/utils/types.ts';
 import useSSECondition, { RELOAD_INTERVAL, RELOAD_MAX_COUNT } from '@/store/useSSECondition.ts';
 import { fetchEventSource } from '@/utils/api.ts';
@@ -21,6 +21,7 @@ const useSSEManager = () => {
   const errorCount = useSSECondition(state => state.errorCount);
   const setError = useSSECondition(state => state.setError);
   const resetError = useSSECondition(state => state.resetError);
+  const isError = useSSECondition(state => state.isError);
 
   // connection
   useEffect(() => {
@@ -46,6 +47,11 @@ const useSSEManager = () => {
       });
   }, [alwaysReload, needCount, queryClient, setError, forceReloadNumber, resetError, errorCount]);
   // 조건이 바뀌었을 때, 연결이 끊어졌을 때 다시 연결
+
+  // 에러가 발생했을 때, 알림을 보내주기
+  useEffect(() => {
+    if (isError) showNotification('알림이 중지되었습니다. 다시 연결해주세요.');
+  }, [isError]);
 };
 
 const fetchSSEData = (queryClient: QueryClient, resetError: () => void) => {

--- a/packages/client/src/pages/wishlist/WishTable.tsx
+++ b/packages/client/src/pages/wishlist/WishTable.tsx
@@ -7,6 +7,7 @@ import useFavorites from '@/store/useFavorites.ts';
 import useWishSearchStore from '@/store/useWishSearchStore.ts';
 import { useJoinPreSeats } from '@/hooks/joinSubjects.ts';
 import useSearchRank from '@/hooks/useSearchRank.ts';
+import TableColorInfo from '@/components/wishTable/TableColorInfo.tsx';
 
 function WishTable() {
   const filterParams = useWishSearchStore(state => state.searchParams);
@@ -43,6 +44,7 @@ function WishTable() {
           <Searches />
 
           {/* Course Table */}
+          <TableColorInfo />
           <div className="bg-white mt-6 shadow-md rounded-lg overflow-x-auto">
             <Table data={filteredData} isPending={isPending} />
           </div>

--- a/packages/client/src/store/useLiveTableStore.ts
+++ b/packages/client/src/store/useLiveTableStore.ts
@@ -1,0 +1,45 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+import { SseSubject } from '@/hooks/server/useSSESeats.ts';
+
+export interface HeadTitle {
+  title: string;
+  visible: boolean;
+  key: keyof SseSubject;
+}
+
+const DefaultTableHeadTitles: HeadTitle[] = [
+  { title: '과목코드', visible: true, key: 'code' },
+  { title: '과목명', visible: true, key: 'name' },
+  { title: '담당교수', visible: true, key: 'professor' },
+  { title: '여석', visible: true, key: 'seat' },
+  { title: '최근갱신', visible: true, key: 'queryTime' },
+
+  { title: '학과명', visible: false, key: 'manageDeptNm' },
+  { title: '수강학년', visible: false, key: 'studentYear' },
+  { title: '수업시간', visible: false, key: 'lesnTime' },
+  { title: '수업실', visible: false, key: 'lesnRoom' },
+  { title: '학점', visible: false, key: 'tmNum' },
+  { title: '비고', visible: false, key: 'remark' },
+  { title: '수업유형', visible: false, key: 'curiTypeCdNm' },
+  { title: '수업언어', visible: false, key: 'curiLangNm' },
+];
+
+export interface LiveTableStore {
+  tableTitles: HeadTitle[];
+  setTableTitles: (titles: HeadTitle[]) => void;
+  resetTableTitles: () => void;
+}
+
+export const useLiveTableStore = create<LiveTableStore>()(
+  persist(
+    set => ({
+      tableTitles: DefaultTableHeadTitles,
+      setTableTitles: titles => set({ tableTitles: titles }),
+      resetTableTitles: () => set({ tableTitles: DefaultTableHeadTitles }),
+    }),
+    {
+      name: 'live-table-head-store',
+    },
+  ),
+);


### PR DESCRIPTION
## 작업 내용
- 과목 분석 상태 -> 폐강됨/영어강좌 등 정보 추가
- 알림과목 SSE 연결 끊어졌을 때, Notification 주기 + UI 추가하기
- SSE 재연결 안되는 버그 수정
- 폐강됨, 영어강좌 색상 -> 설명하기
- 과목 정보(column) - 커스텀 하는 UI 만들기


## 변경 사항 및 리뷰 포인트
일단, Live 페이지에서, Table column 순서 바꾸는 기능은 시간 내에 완성하지 못할 것 같아서, 다음 기회에 만들면 어떨까 합니다.