### PR TITLE
feat: preSeat 서비스 오픈 여부 결정하는 훅 구현

### DIFF
--- a/packages/client/src/components/live/errors/ServiceSoon.tsx
+++ b/packages/client/src/components/live/errors/ServiceSoon.tsx
@@ -1,14 +1,21 @@
 import NoneLayout from '@/components/live/NoneLayout.tsx';
 import ListSVG from '@/assets/list.svg?react';
 
-function ZeroListError() {
+interface ServiceSoonProps {
+  title?: string;
+}
+
+function ServiceSoon({ title }: ServiceSoonProps) {
+  const defaultTitle = '수강여석';
+  const displayTitle = title ? title : defaultTitle;
+
   return (
     <NoneLayout
-      title="잠시후 수강여석 서비스가 오픈됩니다."
-      description="잠시만 기다려주세요."
+      title={`${displayTitle} 서비스가 현재 종료되었습니다.`}
+      description="서비스가 다시 제공될 예정입니다."
       icon={<ListSVG className="w-7 h-7" />}
     />
   );
 }
 
-export default ZeroListError;
+export default ServiceSoon;

--- a/packages/client/src/components/wishTable/Table.tsx
+++ b/packages/client/src/components/wishTable/Table.tsx
@@ -10,6 +10,7 @@ import SkeletonRows from '@/components/live/skeletons/SkeletonRows.tsx';
 // import AlarmButton from '@/components/live/AlarmButton.tsx';
 import FavoriteButton from '@/components/wishTable/FavoriteButton.tsx';
 import SearchSvg from '@/assets/search.svg?react';
+import usePreSeatGate from '@/hooks/usePreSeatGate';
 
 interface ITable {
   data: Wishes[] | (Wishes & IPreRealSeat)[] | undefined;
@@ -29,8 +30,9 @@ export const TableHeaders = [
 
 function Table({ data, isPending = false }: Readonly<ITable>) {
   const hasPreSeats = data && data[0] && 'seat' in data[0];
+  const { isPreSeatAvailable } = usePreSeatGate({ hasSeats: hasPreSeats });
 
-  const headers = hasPreSeats ? TableHeaders : TableHeaders.filter(header => header.key !== 'seat');
+  const headers = isPreSeatAvailable ? TableHeaders : TableHeaders.filter(header => header.key !== 'seat');
 
   return (
     <table className="w-full bg-white rounded-lg relative text-sm">
@@ -55,8 +57,9 @@ function TableBody({ data, isPending = false }: Readonly<ITable>) {
   const wishes = data ? data.slice(0, visibleRows) : [];
 
   const hasPreSeats = data && data[0] && 'seat' in data[0];
+  const { isPreSeatAvailable } = usePreSeatGate({ hasSeats: hasPreSeats });
 
-  const headers = hasPreSeats ? TableHeaders : TableHeaders.filter(header => header.key !== 'seat');
+  const headers = isPreSeatAvailable ? TableHeaders : TableHeaders.filter(header => header.key !== 'seat');
 
   if (isPending || !data) {
     return <SkeletonRows row={5} col={TableHeaders.length} />;

--- a/packages/client/src/hooks/usePreSeatGate.ts
+++ b/packages/client/src/hooks/usePreSeatGate.ts
@@ -1,12 +1,11 @@
-export type PreSeatMode = 'force-off' | 'auto' | 'force-on';
-export const PRESEAT_MODE: PreSeatMode = 'force-on';
+export type PreSeatMode = 'force-open' | 'auto' | 'force-close';
+export const PRESEAT_MODE: PreSeatMode = 'force-open';
 
 /**
  * preSeat의 가용성을 판단하는 훅입니다.
- * force-off: 항상 비활성화합니다.
- * force-on: 항상 활성화합니다.
+ * force-close: 항상 비활성화합니다.
+ * force-open: 항상 활성화합니다.
  * auto: hasSeats가 true면 활성화, false면 비활성화합니다.
- *
  * @param mode
  * @param opts
  * @returns
@@ -15,11 +14,11 @@ function usePreSeatGate(opts?: { hasSeats?: boolean }) {
   const { hasSeats } = opts ?? {};
 
   const getPreSeatAvailable = () => {
-    if (PRESEAT_MODE === 'force-off') {
+    if (PRESEAT_MODE === 'force-close') {
       return false;
     }
 
-    if (PRESEAT_MODE === 'force-on') {
+    if (PRESEAT_MODE === 'force-open') {
       return true;
     }
 

--- a/packages/client/src/hooks/usePreSeatGate.ts
+++ b/packages/client/src/hooks/usePreSeatGate.ts
@@ -6,7 +6,6 @@ export const PRESEAT_MODE: PreSeatMode = 'force-open';
  * force-close: 항상 비활성화합니다.
  * force-open: 항상 활성화합니다.
  * auto: hasSeats가 true면 활성화, false면 비활성화합니다.
- * @param mode
  * @param opts
  * @returns
  */

--- a/packages/client/src/hooks/usePreSeatGate.ts
+++ b/packages/client/src/hooks/usePreSeatGate.ts
@@ -1,0 +1,34 @@
+export type PreSeatMode = 'force-off' | 'auto' | 'force-on';
+export const PRESEAT_MODE: PreSeatMode = 'force-on';
+
+/**
+ * preSeat의 가용성을 판단하는 훅입니다.
+ * force-off: 항상 비활성화합니다.
+ * force-on: 항상 활성화합니다.
+ * auto: hasSeats가 true면 활성화, false면 비활성화합니다.
+ *
+ * @param mode
+ * @param opts
+ * @returns
+ */
+function usePreSeatGate(opts?: { hasSeats?: boolean }) {
+  const { hasSeats } = opts ?? {};
+
+  const getPreSeatAvailable = () => {
+    if (PRESEAT_MODE === 'force-off') {
+      return false;
+    }
+
+    if (PRESEAT_MODE === 'force-on') {
+      return true;
+    }
+
+    return Boolean(hasSeats);
+  };
+
+  const isPreSeatAvailable = getPreSeatAvailable();
+
+  return { isPreSeatAvailable };
+}
+
+export default usePreSeatGate;

--- a/packages/client/src/hooks/usePreSeatGate.ts
+++ b/packages/client/src/hooks/usePreSeatGate.ts
@@ -1,5 +1,5 @@
 export type PreSeatMode = 'force-open' | 'auto' | 'force-close';
-export const PRESEAT_MODE: PreSeatMode = 'force-open';
+export const PRESEAT_MODE: PreSeatMode = 'force-close';
 
 /**
  * preSeat의 가용성을 판단하는 훅입니다.

--- a/packages/client/src/hooks/useWishesPreSeats.ts
+++ b/packages/client/src/hooks/useWishesPreSeats.ts
@@ -21,7 +21,7 @@ function useWishesPreSeats(tableTitles: TableNames[]) {
     return [...tableTitles, { title: '여석', key: 'seat' }];
   }, [data, tableTitles]);
 
-  return { data, titles, isPending };
+  return { data, titles, isPending, hasRealSeats };
 }
 
 export default useWishesPreSeats;

--- a/packages/client/src/pages/PreSeat.tsx
+++ b/packages/client/src/pages/PreSeat.tsx
@@ -59,7 +59,9 @@ const PreSeatBody = ({ search, isMobile }: { search: ISubjectSearch; isMobile: b
           )}
         </CardWrap>
       ) : (
-        <ServiceSoon title="전체 학년 여석" />
+        <div className="flex justify-center w-full h-96">
+          <ServiceSoon title="전체 학년 여석" />
+        </div>
       )}
     </>
   );

--- a/packages/client/src/pages/PreSeat.tsx
+++ b/packages/client/src/pages/PreSeat.tsx
@@ -50,19 +50,21 @@ const PreSeatBody = ({ search, isMobile }: { search: ISubjectSearch; isMobile: b
 
   return (
     <>
-      {isPreSeatAvailable ? (
-        <CardWrap>
-          {isMobile ? (
-            <SubjectCards subjects={filteredData} isPending={isPending} isLive={true} />
-          ) : (
-            <SubjectTable titles={titles} subjects={filteredData} isPending={isPending} />
-          )}
-        </CardWrap>
-      ) : (
-        <div className="flex justify-center w-full h-96">
-          <ServiceSoon title="전체 학년 여석" />
-        </div>
-      )}
+      <CardWrap>
+        {isPreSeatAvailable ? (
+          <>
+            {isMobile ? (
+              <SubjectCards subjects={filteredData} isPending={isPending} isLive={true} />
+            ) : (
+              <SubjectTable titles={titles} subjects={filteredData} isPending={isPending} />
+            )}
+          </>
+        ) : (
+          <div className="flex justify-center w-full h-96">
+            <ServiceSoon title="전체 학년 여석" />
+          </div>
+        )}
+      </CardWrap>
     </>
   );
 };

--- a/packages/client/src/pages/wishlist/WishesDetail.tsx
+++ b/packages/client/src/pages/wishlist/WishesDetail.tsx
@@ -13,6 +13,7 @@ import useDetailRegisters from '@/hooks/server/useDetailRegisters.ts';
 import { getSeatColor, getWishesColor } from '@/utils/colors.ts';
 import FavoriteButton from '@/components/wishTable/FavoriteButton.tsx';
 import AlarmButton from '@/components/live/AlarmButton.tsx';
+import usePreSeatGate from '@/hooks/usePreSeatGate';
 
 ChartJS.register(ArcElement, Tooltip, Legend, BarElement, CategoryScale, LinearScale);
 
@@ -38,6 +39,8 @@ function WishesDetail() {
   );
 
   const hasPreSeats = wishes && 'seat' in wishes;
+  const { isPreSeatAvailable } = usePreSeatGate({ hasSeats: hasPreSeats });
+
   const seats = hasPreSeats ? wishes.seat : -1;
 
   const data = wishes ?? InitWishes;
@@ -95,7 +98,7 @@ function WishesDetail() {
                 {' '}
                 | {data.lesnRoom} | {data.lesnTime}
               </span>
-              {hasPreSeats && (
+              {isPreSeatAvailable && (
                 <p className={`text-sm px-2 py-1 rounded-full font-bold ${getSeatColor(seats)}`}>
                   여석: {seats < 0 ? '???' : seats}
                 </p>


### PR DESCRIPTION
## 작업 내용
preSeat 서비스를 열고 닫는 기능을 구현하였습니다.
preSeat는 전체 여석을 보여주는 기능으로, 실시간 서비스가 시작되면, 해당 서비스는 UI에서 보여지지 않아야합니다.

다음 두 가지 상황을  고려하였습니다.
1. 여러 곳에 퍼져있는 preSeat을 한 곳에서 집중적으로 관리할 수 있으면 좋을 것 같다고 생각하였습니다.
2. 최소한의 코드 변경으로 서비스를 제어할 수 있어야 한다.

우선 preSeat이 보여지는 UI는 다음 세 곳 입니다.
1. 관심과목 탭
3. 관심과목 분석 페이지
4. 전체 여석 페이지

preSeat을 제어하는 방법으로는 아래 두 가지 방법을 생각하였습니다.

### 방법 1: preSeat.json 파일
preSeat.json 파일의 여석 존재 여부로 UI를 제어합니다.
hasPreSeat으로, preSeat이 존재한다면 UI에 보여지게 합니다.


### 방법 2: 상수 값 기반 
`isPreSeatAvailable`과 같은 상수 값으로 서비스 오픈을 제어합니다.
 

현재 관심과목 탭에서는 preSeat.json에 따라서 여석 공개 여부를 결정합니다. 따라서 `isPreSeatAvailable`와 같이 사용하게 될 경우, `isPreSeatAvailable`는 false이지만, 사용자의 브라우저에 따라서 캐싱 문제가 발생하면, 여석이 관심과목에서는 보이지만, 전체 여석 확인 탭에서는 보이지 않는 혼란스러운 상황이 발생하게 됩니다.

이에 따라 다음 세 가지 제어 상수로, 방법 1과 방법 2를 상황에 따라 제어할 수 있도록 훅을 구현하였습니다.

```js
export type PreSeatMode = 'force-open' | 'auto' | 'force-close';
export const PRESEAT_MODE: PreSeatMode = 'force-close';

```

### force-off
force-off: 강제로 서비스를 닫습니다.
preSeat.json 값이 있어도, 여석은 보여지지 않게 됩니다. 

### force-on
force-open: 강제로 서비스를 오픈합니다. 

이 상수 값을 사용하면 단점이 있습니다. 서비스가 오픈되어도, preSeat.json이 null이 뜰 수 있습니다.
> 이 경우에는 여석이 보이지 않을 경우, 새로 고침해달라는 문구를 넣어도 좋을 거 같아요!

<img width="1043" height="464" alt="스크린샷 2025-08-17 오후 1 58 50" src="https://github.com/user-attachments/assets/6ccbf437-ed97-4bfb-818f-ebbf5f81a680" />

### auto
auto: 여석의 여부에 따라, 서비스의 오픈 여부가 결정 됩니다. (임시)
-> preSeat.json이 있다면 오픈, 없다면 close됩니다.

## 변경 사항 및 리뷰 포인트

일단 이렇게 설계 해보았는데, 수정해야할 부분이나 더 좋은 의견이 있다면 알려주심 감사하겠습니다 🙇

