### PR TITLE
올클연습 버그 수정

### DIFF
--- a/packages/client/src/components/simulation/SimulationSearchForm.tsx
+++ b/packages/client/src/components/simulation/SimulationSearchForm.tsx
@@ -15,7 +15,7 @@ import React from 'react';
 
 function SimulationSearchForm() {
   const { setCurrentSimulation, currentSimulation, resetSimulation } = useSimulationProcessStore();
-  const { openModal } = useSimulationModalStore();
+  const openModal = useSimulationModalStore(state => state.openModal);
   const ongoingSimulation = useLiveQuery(checkOngoingSimulation);
   const { reloadSimulationStatus } = useReloadSimulation();
   const { data: lectures } = useLectures();

--- a/packages/client/src/components/simulation/detail/SubjectAllResult.tsx
+++ b/packages/client/src/components/simulation/detail/SubjectAllResult.tsx
@@ -25,7 +25,7 @@ function SubjectAllResult({ result }: Readonly<{ result: AggregatedResultRespons
             <td className="py-2 px-1">{row.subjectCode + '-' + row.classCode}</td>
             <td className="py-2 px-1">{row.subjectName}</td>
             <td className="py-2 px-1">{row.professorName}</td>
-            <td className="py-2 px-1">{row.avgIndex}</td>
+            <td className="py-2 px-1">{row.avgIndex.toFixed(2)}</td>
             <td className="py-2 px-1">{row.avgCompletionTime.toFixed(2) + ' sec'}</td>
             <td className="py-2 px-2">
               <span className="px-1 py-0.5 rounded-full text-xs font-bold text-green-500">{row.successCount}</span>/

--- a/packages/client/src/components/simulation/modal/CaptchaInput.tsx
+++ b/packages/client/src/components/simulation/modal/CaptchaInput.tsx
@@ -20,7 +20,8 @@ function CaptchaInput() {
   const codeRef = useRef<string>('');
   const { data: lectures } = useLectures();
 
-  const { closeModal, openModal } = useSimulationModalStore();
+  const openModal = useSimulationModalStore(state => state.openModal);
+  const closeModal = useSimulationModalStore(state => state.closeModal);
   const { currentSubjectId, setSubjectStatus, setCaptchaFailed } = useSimulationSubjectStore();
 
   function handleRefreshCaptcha() {

--- a/packages/client/src/components/simulation/modal/Processing.tsx
+++ b/packages/client/src/components/simulation/modal/Processing.tsx
@@ -2,7 +2,7 @@ import Modal from '@/components/simulation/modal/Modal';
 import { useSimulationModalStore } from '@/store/simulation/useSimulationModal';
 
 function ProcessingModal() {
-  const { closeModal } = useSimulationModalStore();
+  const closeModal = useSimulationModalStore(state => state.closeModal);
   return (
     <Modal onClose={() => closeModal()}>
       <div className="p-6 w-80 bg-white rounded shadow">

--- a/packages/client/src/components/simulation/modal/SimulationModal.tsx
+++ b/packages/client/src/components/simulation/modal/SimulationModal.tsx
@@ -55,7 +55,7 @@ function SimulationModal({ reloadSimulationStatus }: Readonly<ISimulationModal>)
   const { setCurrentSimulation } = useSimulationProcessStore();
   const { data: lectures } = useLectures();
 
-  const currentSubjectStatus = subjectStatusMap[currentSubjectId];
+  const currentSubjectStatus = subjectStatusMap[currentSubjectId]; // useSimulationSubjectStore.subjectStatusMap 여기만 사용함.
   const modalData = SIMULATION_MODAL_CONTENTS.find(data => data.status === currentSubjectStatus);
 
   const modalStatus = modalData?.status ?? APPLY_STATUS.PROGRESS;

--- a/packages/client/src/components/simulation/modal/SimulationModal.tsx
+++ b/packages/client/src/components/simulation/modal/SimulationModal.tsx
@@ -50,9 +50,10 @@ interface ISimulationModal {
 }
 
 function SimulationModal({ reloadSimulationStatus }: Readonly<ISimulationModal>) {
-  const { closeModal, openModal } = useSimulationModalStore();
+  const openModal = useSimulationModalStore(state => state.openModal);
+  const closeModal = useSimulationModalStore(state => state.closeModal);
   const { currentSubjectId, setSubjectStatus, subjectStatusMap } = useSimulationSubjectStore();
-  const { setCurrentSimulation } = useSimulationProcessStore();
+  const setCurrentSimulation = useSimulationProcessStore(state => state.setCurrentSimulation);
   const { data: lectures } = useLectures();
 
   const currentSubjectStatus = subjectStatusMap[currentSubjectId]; // useSimulationSubjectStore.subjectStatusMap 여기만 사용함.

--- a/packages/client/src/components/simulation/modal/SimulationResultModal.tsx
+++ b/packages/client/src/components/simulation/modal/SimulationResultModal.tsx
@@ -68,7 +68,7 @@ function SimulationResultModal({ simulationId }: Readonly<{ simulationId: number
     <ProcessingModal />
   ) : (
     <Modal onClose={() => closeModal()}>
-      <div className="w-[100%] sm:w-full max-w-md bg-white rounded-xl shadow-xl p-6 relative overflow-hidden">
+      <div className="w-full max-w-md bg-white rounded-xl shadow-xl p-6 relative overflow-hidden">
         {isSuccessSimulation && (
           <div className="absolute inset-0 pointer-events-none">
             <div className="animate-float1 absolute top-6 left-6 w-3 h-3 bg-red-400 rounded-full" />

--- a/packages/client/src/components/simulation/modal/SimulationResultModal.tsx
+++ b/packages/client/src/components/simulation/modal/SimulationResultModal.tsx
@@ -8,7 +8,8 @@ import { useLiveQuery } from 'dexie-react-hooks';
 import { getAggregatedSimulationResults } from '@/utils/simulation/result';
 
 function SimulationResultModal({ simulationId }: Readonly<{ simulationId: number }>) {
-  const { closeModal, openModal } = useSimulationModalStore();
+  const openModal = useSimulationModalStore(state => state.openModal);
+  const closeModal = useSimulationModalStore(state => state.closeModal);
   const [result, setResult] = useState<{ accuracy: number; score: number; total_elapsed: number } | null>(null);
   const [logParam, setLogParam] = useState<number>();
 

--- a/packages/client/src/components/simulation/modal/WaitingModal.tsx
+++ b/packages/client/src/components/simulation/modal/WaitingModal.tsx
@@ -112,7 +112,7 @@ function WaitingModal() {
   };
 
   return (
-    <Modal onClose={() => closeModal()}>
+    <Modal onClose={() => {}}>
       <div className="sm:w-full max-w-md bg-white rounded-sm shadow-xl p-6 text-center space-y-6">
         <h2 className="text-lg md:text-xl font-semibold text-gray-800">
           서비스 <span className="text-blue-600 font-bold">접속대기 중</span>입니다.

--- a/packages/client/src/components/simulation/modal/WaitingModal.tsx
+++ b/packages/client/src/components/simulation/modal/WaitingModal.tsx
@@ -39,8 +39,9 @@ function WaitingModal() {
   const [timer, setTimer] = useState(0);
 
   const intervalRef = useRef<NodeJS.Timeout | null>(null);
-  const { closeModal } = useSimulationModalStore();
-  const { currentSimulation, setCurrentSimulation } = useSimulationProcessStore();
+  const closeModal = useSimulationModalStore(state => state.closeModal);
+  const currentSimulation = useSimulationProcessStore(state => state.currentSimulation);
+  const setCurrentSimulation = useSimulationProcessStore(state => state.setCurrentSimulation);
 
   const unit = 0.2;
   const peoplePerUnit = 98;

--- a/packages/client/src/components/simulation/modal/before/TutorialModal.tsx
+++ b/packages/client/src/components/simulation/modal/before/TutorialModal.tsx
@@ -49,7 +49,8 @@ function TutorialModal() {
   const [currentIndex, setCurrentIndex] = useState(0);
   const [popupChecked, setPopupChecked] = useState(false);
 
-  const { closeModal, openModal } = useSimulationModalStore();
+  const openModal = useSimulationModalStore(state => state.openModal);
+  const closeModal = useSimulationModalStore(state => state.closeModal);
   const isMobile = useMobile();
   const youTubeSize = isMobile ? { width: '250', height: '141' } : { width: '600', height: '338' };
   const showTutorial = checkExpiredTutorialPop();

--- a/packages/client/src/components/simulation/modal/before/UserWishModal.tsx
+++ b/packages/client/src/components/simulation/modal/before/UserWishModal.tsx
@@ -76,7 +76,6 @@ function UserWishModal({ timetables, setIsModalOpen }: Readonly<UserWishModalIPr
         setCurrentSimulation({
           simulationId,
           simulationStatus: isRunning ? 'start' : 'before',
-          simulatonSubjects: simulationSubjects,
         });
       } else {
         console.error('시뮬레이션 시작 결과가 유효하지 않음', result);

--- a/packages/client/src/components/simulation/table/SubjectsTable.tsx
+++ b/packages/client/src/components/simulation/table/SubjectsTable.tsx
@@ -11,9 +11,9 @@ interface ISubjectsTable {
 }
 
 const SubjectsTable = ({ isRegisteredTable }: ISubjectsTable) => {
-  const { currentSimulation } = useSimulationProcessStore();
-  const { openModal } = useSimulationModalStore();
-  const { setCurrentSubjectId } = useSimulationSubjectStore();
+  const currentSimulation = useSimulationProcessStore(state => state.currentSimulation);
+  const openModal = useSimulationModalStore(state => state.openModal);
+  const setCurrentSubjectId = useSimulationSubjectStore(state => state.setCurrentSubjectId);
   const { data: lectures } = useLectures();
 
   const handleClickSubject = (subjectId: number) => {

--- a/packages/client/src/components/simulation/table/SubjectsTable.tsx
+++ b/packages/client/src/components/simulation/table/SubjectsTable.tsx
@@ -31,9 +31,11 @@ const SubjectsTable = ({ isRegisteredTable }: ISubjectsTable) => {
     openModal('captcha');
   };
 
-  const mergeNonRegisteredAndFailed = currentSimulation.nonRegisteredSubjects.concat(currentSimulation.failedSubjects);
+  // const mergeNonRegisteredAndFailed = currentSimulation.nonRegisteredSubjects.concat(currentSimulation.failedSubjects);
 
-  const subjectsToRender = isRegisteredTable ? currentSimulation.successedSubjects : mergeNonRegisteredAndFailed;
+  const subjectsToRender = isRegisteredTable
+    ? currentSimulation.registeredSubjects
+    : currentSimulation.nonRegisteredSubjects;
 
   return subjectsToRender.length > 0 ? (
     subjectsToRender.map((subject, idx) => (

--- a/packages/client/src/hooks/useReloadSimulation.ts
+++ b/packages/client/src/hooks/useReloadSimulation.ts
@@ -6,8 +6,9 @@ import { useSimulationModalStore } from '@/store/simulation/useSimulationModal';
 import useLectures from './server/useLectures';
 
 export function useReloadSimulation() {
-  const { setCurrentSimulation, currentSimulation } = useSimulationProcessStore();
-  const { openModal } = useSimulationModalStore();
+  const setCurrentSimulation = useSimulationProcessStore(state => state.setCurrentSimulation);
+  const currentSimulation = useSimulationProcessStore(state => state.currentSimulation);
+  const openModal = useSimulationModalStore(state => state.openModal);
   const { data: lectures } = useLectures();
 
   const loadCurrentSimulation = (

--- a/packages/client/src/hooks/useReloadSimulation.ts
+++ b/packages/client/src/hooks/useReloadSimulation.ts
@@ -30,48 +30,46 @@ export function useReloadSimulation() {
     }
   };
 
-  function getSubjectsWithStatusSuccess(
-    registeredSubjects: { subjectId: number }[],
-    key: 'successedSubjects' | 'failedSubejcts',
-    subjectStatus: { subjectId: number; status: number }[],
-  ) {
-    if (key === 'successedSubjects') {
-      const statusSuccessedIds = subjectStatus.filter(status => status.status === 1).map(status => status.subjectId);
-      return registeredSubjects.filter(subject => statusSuccessedIds.includes(subject.subjectId));
-    } else {
-      const statusFailedIds = subjectStatus.filter(status => status.status === 2).map(status => status.subjectId);
-      return registeredSubjects.filter(subject => statusFailedIds.includes(subject.subjectId));
-    }
-  }
+  // function getSubjectsWithStatusSuccess(
+  //   registeredSubjects: { subjectId: number }[],
+  //   key: 'successedSubjects' | 'failedSubejcts',
+  //   subjectStatus: { subjectId: number; status: number }[],
+  // ) {
+  //   if (key === 'successedSubjects') {
+  //     const statusSuccessedIds = subjectStatus.filter(status => status.status === 1).map(status => status.subjectId);
+  //     return registeredSubjects.filter(subject => statusSuccessedIds.includes(subject.subjectId));
+  //   } else {
+  //     const statusFailedIds = subjectStatus.filter(status => status.status === 2).map(status => status.subjectId);
+  //     return registeredSubjects.filter(subject => statusFailedIds.includes(subject.subjectId));
+  //   }
+  // }
 
   const reloadSimulationStatus = () => {
     getSimulateStatus()
       .then(result => {
         if (!result || result.simulationId === -1) return;
 
-        setCurrentSimulation({
-          simulationId: result.simulationId,
-        });
+        setCurrentSimulation({ simulationId: result.simulationId });
 
         if (result?.nonRegisteredSubjects) {
           loadCurrentSimulation(result.nonRegisteredSubjects, 'nonRegisteredSubjects', result.simulationId);
         }
 
         if (result?.registeredSubjects) {
-          const filteredSuccessedSubjects = getSubjectsWithStatusSuccess(
-            result.registeredSubjects,
-            'successedSubjects',
-            result.subjectStatus,
-          );
+          // const filteredSuccessedSubjects = getSubjectsWithStatusSuccess(
+          //   result.registeredSubjects,
+          //   'successedSubjects',
+          //   result.subjectStatus,
+          // );
+          //
+          // const filteredFailedSubjects = getSubjectsWithStatusSuccess(
+          //   result.registeredSubjects,
+          //   'failedSubejcts',
+          //   result.subjectStatus,
+          // );
 
-          const filteredFailedSubjects = getSubjectsWithStatusSuccess(
-            result.registeredSubjects,
-            'failedSubejcts',
-            result.subjectStatus,
-          );
-
-          loadCurrentSimulation(filteredSuccessedSubjects, 'successedSubjects', result.simulationId);
-          loadCurrentSimulation(filteredFailedSubjects, 'failedSubjects', result.simulationId);
+          // loadCurrentSimulation(filteredSuccessedSubjects, 'successedSubjects', result.simulationId);
+          // loadCurrentSimulation(filteredFailedSubjects, 'failedSubjects', result.simulationId);
           loadCurrentSimulation(result.registeredSubjects, 'registeredSubjects', result.simulationId);
         }
       })

--- a/packages/client/src/pages/simulation/Simulation.tsx
+++ b/packages/client/src/pages/simulation/Simulation.tsx
@@ -97,7 +97,7 @@ function Simulation() {
     checkHasSimulation();
   }, [currentSimulation.simulationStatus]);
 
-  const totalCredits = currentSimulation.successedSubjects.reduce((acc, subject) => {
+  const totalCredits = currentSimulation.registeredSubjects.reduce((acc, subject) => {
     const firstNumber = subject.tm_num.split('/')[0];
     return acc + parseInt(firstNumber, 10);
   }, 0);

--- a/packages/client/src/store/simulation/useSimulationProcess.ts
+++ b/packages/client/src/store/simulation/useSimulationProcess.ts
@@ -1,49 +1,47 @@
-import { APPLY_STATUS } from '@/utils/simulation/simulation';
+// import { APPLY_STATUS } from '@/utils/simulation/simulation';
 import { SimulationStatusType, SimulationSubject } from '@/utils/types';
 import { create } from 'zustand';
 
-interface SubjectStatus {
-  subjectId: number;
-  subjectStatus: APPLY_STATUS;
-}
+// interface SubjectStatus {
+//   subjectId: number;
+//   subjectStatus: APPLY_STATUS;
+// }
 
 interface SimulationState {
   simulationId: number;
-  simulatonSubjects: SimulationSubject[]; // 안씀 (불러오는 로직만 있음)
   registeredSubjects: SimulationSubject[]; // 신청 학점 수 판별...
   nonRegisteredSubjects: SimulationSubject[]; // failedSubjects 랑 같이 씀.
-  successedSubjects: SimulationSubject[]; // 신청학점 판단, registeredSubjects 동일.
-  failedSubjects: SimulationSubject[]; // non-registered 제대로 판단할 때 씀.
+  // successedSubjects: SimulationSubject[]; // 신청학점 판단, registeredSubjects 동일.
+  // failedSubjects: SimulationSubject[]; // non-registered 제대로 판단할 때 씀.
   simulationStatus: SimulationStatusType; // 전역적으로 상태 판단 (동기 + 비동기 상태 둘 다 일것 같은데 확인 필요)
   clickedTime: number; // 검색 버튼 클릭한 시간 (밀리초) - 대기시간 판별 용
 }
 
 interface IUseSimulationProcessStore {
   currentSimulation: SimulationState;
-  subjectsStatus: SubjectStatus[]; // 안씀
+  // subjectsStatus: SubjectStatus[]; // 안씀
   setCurrentSimulation: (simulation: Partial<SimulationState>) => void;
   resetSimulation: () => void;
 }
 
 const defaultSimulation: SimulationState = {
   simulationId: -1,
-  simulatonSubjects: [],
   registeredSubjects: [],
   nonRegisteredSubjects: [],
-  successedSubjects: [],
-  failedSubjects: [],
+  // successedSubjects: [],
+  // failedSubjects: [],
   simulationStatus: 'before',
   clickedTime: 0,
 };
 
 const useSimulationProcessStore = create<IUseSimulationProcessStore>(set => ({
   currentSimulation: defaultSimulation,
-  subjectsStatus: [],
+  // subjectsStatus: [],
   setCurrentSimulation: simulation =>
     set(state => ({
       currentSimulation: { ...state.currentSimulation, ...simulation },
     })),
-  resetSimulation: () => set({ currentSimulation: defaultSimulation, subjectsStatus: [] }),
+  resetSimulation: () => set({ currentSimulation: defaultSimulation /*, subjectsStatus: []*/ }),
 }));
 
 export default useSimulationProcessStore;

--- a/packages/client/src/store/simulation/useSimulationProcess.ts
+++ b/packages/client/src/store/simulation/useSimulationProcess.ts
@@ -9,13 +9,13 @@ interface SubjectStatus {
 
 interface SimulationState {
   simulationId: number;
-  simulatonSubjects: SimulationSubject[];
-  registeredSubjects: SimulationSubject[];
-  nonRegisteredSubjects: SimulationSubject[];
-  successedSubjects: SimulationSubject[];
-  failedSubjects: SimulationSubject[];
-  simulationStatus: SimulationStatusType;
-  clickedTime: number;
+  simulatonSubjects: SimulationSubject[]; // 안씀 (불러오는 로직만 있음)
+  registeredSubjects: SimulationSubject[]; // 신청 학점 수 판별...
+  nonRegisteredSubjects: SimulationSubject[]; // failedSubjects 랑 같이 씀.
+  successedSubjects: SimulationSubject[]; // 신청학점 판단, registeredSubjects 동일.
+  failedSubjects: SimulationSubject[]; // non-registered 제대로 판단할 때 씀.
+  simulationStatus: SimulationStatusType; // 전역적으로 상태 판단 (동기 + 비동기 상태 둘 다 일것 같은데 확인 필요)
+  clickedTime: number; // 검색 버튼 클릭한 시간 (밀리초) - 대기시간 판별 용
 }
 
 interface IUseSimulationProcessStore {

--- a/packages/client/src/store/simulation/useSimulationProcess.ts
+++ b/packages/client/src/store/simulation/useSimulationProcess.ts
@@ -20,7 +20,7 @@ interface SimulationState {
 
 interface IUseSimulationProcessStore {
   currentSimulation: SimulationState;
-  subjectsStatus: SubjectStatus[];
+  subjectsStatus: SubjectStatus[]; // 안씀
   setCurrentSimulation: (simulation: Partial<SimulationState>) => void;
   resetSimulation: () => void;
 }

--- a/packages/client/src/store/simulation/useSimulationSubject.ts
+++ b/packages/client/src/store/simulation/useSimulationSubject.ts
@@ -7,12 +7,12 @@ interface IUseSimulationSubjectStore {
   isCaptchaFailed: boolean;
   setCurrentSubjectId: (currentSubjectId: number) => void;
   setSubjectStatus: (currentSubjectId: number, status: APPLY_STATUS) => void;
-  getSubjectStatus: (subjectId: string) => APPLY_STATUS | undefined;
-  getIsCaptchaFailed: () => boolean;
+  // getSubjectStatus: (subjectId: string) => APPLY_STATUS | undefined;
+  // getIsCaptchaFailed: () => boolean;
   setCaptchaFailed: (failed: boolean) => void;
 }
 
-const useSimulationSubjectStore = create<IUseSimulationSubjectStore>((set, get) => ({
+const useSimulationSubjectStore = create<IUseSimulationSubjectStore>((set) => ({
   currentSubjectId: 0,
   isCaptchaFailed: false,
   subjectStatusMap: {},
@@ -24,8 +24,8 @@ const useSimulationSubjectStore = create<IUseSimulationSubjectStore>((set, get) 
         [currentSubjectId]: status,
       },
     })),
-  getSubjectStatus: currentSubjectId => get().subjectStatusMap[currentSubjectId],
-  getIsCaptchaFailed: () => get().isCaptchaFailed,
+  // getSubjectStatus: currentSubjectId => get().subjectStatusMap[currentSubjectId],
+  // getIsCaptchaFailed: () => get().isCaptchaFailed,
   setCaptchaFailed: failed => set({ isCaptchaFailed: failed }),
 }));
 

--- a/packages/client/src/utils/simulation/result.ts
+++ b/packages/client/src/utils/simulation/result.ts
@@ -6,9 +6,10 @@ const SEC = 1 / 1000;
 
 export async function getSimulationList() {
   const snapshots = await db.simulation_run.filter(run => run.ended_at !== -1).toArray();
+  const sortedSnapshots = snapshots.sort((a, b) => b.simulation_run_id - a.simulation_run_id);
 
   return {
-    snapshots,
+    snapshots: sortedSnapshots,
   };
 }
 

--- a/packages/client/src/utils/simulation/simulation.ts
+++ b/packages/client/src/utils/simulation/simulation.ts
@@ -61,19 +61,23 @@ export async function checkOngoingSimulation() {
 
     if (!ongoing) return { simulationId: -1 };
 
+    // 진행중인 시뮬레이션 중, 성공 또는 실패한 과목을 불러옵니다.
     const registeredSelections = await db.simulation_run_selections
       .filter(s => submittedFilter(s, ongoing.simulation_run_id))
       .toArray();
 
+    // 진행중인 시뮬레이션의 과목
     const snapshotSubjects = await db.interested_subject.where('snapshot_id').equals(ongoing.snapshot_id).toArray();
     if (!snapshotSubjects) return errMsg(SIMULATION_ERROR.SNAPSHOT_NOT_EXIST);
 
+    // registeredSubjects === successed
+    const successed = registeredSelections.filter(s => s.status === APPLY_STATUS.SUCCESS);
     const registeredSubjects = snapshotSubjects
-      .filter(subject => registeredSelections.some(selection => selection.interested_id === subject.interested_id))
+      .filter(subject => successed.some(selection => selection.interested_id === subject.interested_id))
       .map(subject => ({ subjectId: subject.subject_id }));
 
     const nonRegisteredSubjects = snapshotSubjects
-      .filter(subject => !registeredSelections.some(selection => selection.interested_id === subject.interested_id))
+      .filter(subject => !successed.some(selection => selection.interested_id === subject.interested_id))
       .map(subject => ({ subjectId: subject.subject_id }));
 
     const subjectStatus = registeredSelections.map(selection => {

--- a/packages/client/src/utils/simulation/simulation.ts
+++ b/packages/client/src/utils/simulation/simulation.ts
@@ -300,6 +300,13 @@ export async function triggerButtonEvent(
       return await saveStatus(APPLY_STATUS.CAPTCHA_FAILED);
     }
 
+    // 이미 failed 상태인지 확인합니다. 이미 failed 상태라면, doubled 처리하고, UI만 fail로 표시합니다.
+    const alreadyFailed = selections.some(s => s.interested_id === interestedId && s.status === APPLY_STATUS.FAILED);
+    if (alreadyFailed) {
+      await saveStatus(APPLY_STATUS.DOUBLED);
+      return { status: APPLY_STATUS.FAILED };
+    }
+
     // 과목 중복 여부를 확인합니다.
     const isDouble = selections.some(
       s => s.interested_id === interestedId && s.ended_at >= 0 && submittedFilter(s, latestSimulationId),

--- a/packages/client/src/utils/types.ts
+++ b/packages/client/src/utils/types.ts
@@ -59,6 +59,10 @@ export interface Subject {
   isDeleted: boolean; // 삭제 여부
 }
 
+/** before: 튜토리얼 + 관심과목 선택
+ * start: 시작 -> 대기 -> 과목 불러오기 전
+ * progress: 과목 신청 프로세스
+ * finish: 결과 모달 */
 export type SimulationStatusType = 'before' | 'start' | 'progress' | 'finish';
 
 export interface DepartmentType {


### PR DESCRIPTION
## 작업 내용
올클연습에 남아있던 버그들을 수정했습니다
- 연습 시작 시 대기 모달, 배경 클릭 시 사라지도록 수정
- 과목 신청 실패 후, 다시 신청하면 이미 신청한 과목이라고 나옴 (예상결과: 여석이 없습니다) 수정
- ProcessStore - suceess, fail, subject -> registered, nonRegistered 로 통합
- 결과 - Timeline UI 개선
    - Tooltip 위치 개선
    - 캡차코드 / 재조회 코드 숫자 표시 오류 개선
    - Timeline 에 그려지는 위치, 숫자 버그 개선
- 결과 - 최근 데이터가 가장 최근으로 올라오도록 개선.
-  확대 시 모달창 범위 넘어거는 버그 수정


## 변경 사항 및 리뷰 포인트

- 올클연습 관련 Store (useSimulationProcessStore, useSimulationSubjectStore) 안쓰는 store를 정리했습니다. 관련 store가 정말 필요없는지에 대한 검토가 필요해보입니다.
- 로직이 복잡한 부분이 많아서 추후 간소화하는 작업을 진행하면 좋을 것 같습니다.
  - ProcessStore -> 비동기 Store로 (tanstack 처럼) 관리 (refech, init 등 내부적으로 비동기 훅 정의)
  - Dexiejs 로직 개선