### PR TITLE
hotfix: 실시간 수강 신청 종료 날짜 수정

### DIFF
--- a/packages/client/src/components/live/RealtimeTable.tsx
+++ b/packages/client/src/components/live/RealtimeTable.tsx
@@ -89,7 +89,7 @@ function SubjectBody({ tableTitles }: Readonly<{ tableTitles: HeadTitle<SseSubje
   const HeadTitles = tableTitles.filter(t => t.visible);
 
   // Todo: 추후 변수처리 할 것
-  const isFinishLive = new Date() > getDateLocale('2025-09-05T17:00:00');
+  const isFinishLive = new Date() > getDateLocale('2025-012-03T17:00:00');
   const sseState = useSSEState(state => state.sseState);
 
   if (MAINTENANCE) {


### PR DESCRIPTION
## 작업 내용
실시간 수강 신청 종료 날짜 변경이 필요하여 수정하였습니다.

<img width="1347" height="583" alt="스크린샷 2025-12-01 오후 9 50 36" src="https://github.com/user-attachments/assets/390902e0-e84e-4858-959f-fd71a55a9868" />

## 변경 사항 및 리뷰 포인트
