### PR TITLE
fix: 학과 검색 필터링 오류 수정

### DIFF
--- a/packages/client/src/features/filtering/ui/DepartmentFilter.tsx
+++ b/packages/client/src/features/filtering/ui/DepartmentFilter.tsx
@@ -97,11 +97,7 @@ function SelectSubject({ departments, setFilter, selectedValue }: ISelectSubject
     setFilter('department', department || '');
   };
 
-  const filteredDepartments = departments.filter(
-    department => pickCollegeOrMajor(selectedValue, departments) === department.departmentName,
-  );
-
-  if (filteredDepartments.length === 0) {
+  if (departments.length === 0) {
     return <ZeroContent title="검색 결과가 없습니다." description="다른 학과 이름으로 검색해주세요." />;
   }
 


### PR DESCRIPTION
## 작업 내용
시간표 페이지에서 학과 검색 시 결과가 있음에도 검색 결과가 뜨지 않는 문제를 수정하였습니다.

https://github.com/user-attachments/assets/f8952536-d389-45cf-a406-dc292f47ef5c


## 변경 사항 및 리뷰 포인트
검색결과에 따라 필터링 된 학과 목록을 선택된 학과와 비교하여 다시 필터링하는 로직을 삭제하였습니다.  
