### PR TITLE
feat:관심 과목 데이터 캐시 무효화

### DIFF
--- a/packages/client/src/entities/wishes/api/wishes.ts
+++ b/packages/client/src/entities/wishes/api/wishes.ts
@@ -6,6 +6,7 @@ export interface WishesApiResponse {
   baskets: { subjectId: number; totalCount: number }[];
 }
 
+// baskets.json 파일 업데이트 시 반드시 `CACHE_VERSION` 값을 함께 변경해주세요.
 const CACHE_VERSION = 'SPRING_26_20260130';
 
 export const fetchWishesDataBySemester = async (semester: string) => {


### PR DESCRIPTION
## 작업 내용

관심과목 데이터의 캐시 무효화는 업데이트 시점에 일어나야합니다.
현재는 파일이 업데이트되어도 브라우저 캐시로 인해 이전 데이터가 표시되는 문제가 있었습니다.

- 파일 업데이트 시점에 캐시 무효화가 일어나야함.
- 이후에는 변경될 가능성이 없음.

따라서, 관심 과목 데이터 캐시 무효화를 위해, 캐시 버스터를 추가하였습니다.

## 변경 사항 및 리뷰 포인트
버전 식별자로 **현재 학기 + 파일 업데이트 날짜**를 생각해보았습니다. 
버전 식별자가 적합한지 확인부탁드립니다!


### 고려한 자동화 방안들

1. **빌드 시점마다 `Date.now()`로 자동화**
   - 장점: 깜빡할 일 없음
   - 단점: 파일 변경 없어도 매 빌드마다 캐시 무효화 발생

2. **파일 해시 값으로 관리**
   - 장점: 파일 변경 시에만 자동으로 버전 변경
   - 단점: 빌드 스크립트 추가 필요, 복잡도 증가

### 수동 관리를 선택한 이유

- `baskets.json` 업데이트는 학기당 1-2회 정도로 자주 발생하지 않음
- 간단한 작업을 위해 빌드 프로세스를 복잡하게 만들 필요가 없다고 판단
- 주석으로 충분히 안내 가능
```tsx
// baskets.json 파일 업데이트 시 반드시 CACHE_VERSION 값을 함께 변경해주세요.
const CACHE_VERSION = 'SPRING_26_20260130';
```

혹시 다른 의견이나 더 나은 방법이 있으시면 피드백 부착드립니다!