### PR TITLE
feat: 랜딩 배너 버튼을 실시간 버튼으로 변경

### DIFF
--- a/packages/client/src/widgets/home/ui/MainBanner.tsx
+++ b/packages/client/src/widgets/home/ui/MainBanner.tsx
@@ -38,7 +38,7 @@ function MainBanner() {
 
         <div className="flex flex-col md:flex-row gap-4 mt-4">
           <Button variant="primary" size="medium" asChild>
-            <Link to="/wishes">관심과목 분석 보러가기</Link>
+            <Link to="/live">실시간 여석 확인하기</Link>
           </Button>
           <Button variant="outlined" size="medium" asChild>
             <Link to="/simulation">수강 신청 연습하기</Link>


### PR DESCRIPTION
## 작업 내용
랜딩 페이지의 배너의 관심과목 분석 버튼을 실시간 여석 확인 버튼으로 수정하였습니다. 
<img width="2558" height="1328" alt="image" src="https://github.com/user-attachments/assets/2e418890-9ed1-496f-a752-803f56e06a5d" />

## 변경 사항 및 리뷰 포인트
