### PR TITLE
feat: 이수 과목 GENERAL 카테고리 타입 추가 및 필터 정렬 순서 정의

### DIFF
--- a/packages/client/src/entities/graduation/api/graduation.ts
+++ b/packages/client/src/entities/graduation/api/graduation.ts
@@ -16,7 +16,8 @@ export type CategoryType =
   | 'MAJOR_REQUIRED'
   | 'MAJOR_ELECTIVE'
   | 'MAJOR_BASIC'
-  | 'TOTAL_COMPLETION';
+  | 'TOTAL_COMPLETION'
+  | 'GENERAL';
 
 /** 스코프 타입 */
 export type ScopeType = 'PRIMARY' | 'SECONDARY' | 'MINOR';

--- a/packages/client/src/entities/graduation/lib/rules.ts
+++ b/packages/client/src/entities/graduation/lib/rules.ts
@@ -11,6 +11,19 @@ export const GENERAL_CATEGORY_TYPES: CategoryType[] = [
   'GENERAL_ELECTIVE',
 ];
 
+/** 이수 과목 필터 순서 */
+export const COURSE_CATEGORY_ORDER: CategoryType[] = [
+  'MAJOR_REQUIRED',
+  'MAJOR_ELECTIVE',
+  'MAJOR_BASIC',
+  'COMMON_REQUIRED',
+  'BALANCE_REQUIRED',
+  'ACADEMIC_BASIC',
+  'GENERAL_ELECTIVE',
+  'GENERAL',
+  'TOTAL_COMPLETION',
+];
+
 /** 카테고리 목록에서 특정 타입 찾기 */
 export function findCategory(categories: CategoryProgress[], categoryType: CategoryType): CategoryProgress | undefined {
   return categories.find(cat => cat.categoryType === categoryType);

--- a/packages/client/src/features/graduation/lib/mappers.ts
+++ b/packages/client/src/features/graduation/lib/mappers.ts
@@ -10,6 +10,7 @@ export const CATEGORY_TYPE_LABELS: Record<CategoryType, string> = {
   MAJOR_ELECTIVE: '전공선택',
   MAJOR_BASIC: '전공기초',
   TOTAL_COMPLETION: '총이수학점',
+  GENERAL: '교양',
 };
 
 /** 고전독서 도메인 → 한글 라벨 매핑 */

--- a/packages/client/src/features/graduation/ui/dashboard/EarnedCoursesSection.tsx
+++ b/packages/client/src/features/graduation/ui/dashboard/EarnedCoursesSection.tsx
@@ -3,11 +3,13 @@ import { Flex, Chip, ListboxOption } from '@allcll/allcll-ui';
 import { useGraduationCourses } from '@/entities/graduation/model/useGraduation';
 import type { CategoryType, GraduationCourse } from '@/entities/graduation/api/graduation';
 import { CATEGORY_TYPE_LABELS } from '../../lib/mappers';
+import { COURSE_CATEGORY_ORDER } from '@/entities/graduation/lib/rules';
 import CheckSvg from '@/assets/checkbox-blue.svg?react';
 import ArrowDownSvg from '@/assets/arrow-down-gray.svg?react';
 
 function getUniqueCategories(courses: GraduationCourse[]): CategoryType[] {
-  return Array.from(new Set(courses.map(course => course.categoryType)));
+  const existingCategories = new Set(courses.map(course => course.categoryType));
+  return COURSE_CATEGORY_ORDER.filter(cat => existingCategories.has(cat));
 }
 
 function filterCourses(courses: GraduationCourse[], category: CategoryType | '전체'): GraduationCourse[] {


### PR DESCRIPTION
## 작업 내용
### [QA-145]
해당 QA에서 논의되었던 이수 과목 조회 API 응답에서 새로 추가된 `GENERAL`(교양) 카테고리 타입 정의를 추가하였습니다.
`GENERAL`(교양)은 졸업요건 필수 항목은 아니지만 이수 과목 이력에는 포함되는 과목으로 이수 과목 목록에서 표시 및 필터링이 가능하도록 추가하였습니다. 
또한 이수 과목 필터 드롭다운의 항목 순서를 전공 -> 교양 순으로 정의하여 일정한 순서로 뜨도록 수정하였습니다. 
## 변경 사항 및 리뷰 포인트
한번 확인해보시고 피드백 있으시면 남겨주시면 감사하겠습니다!!!