### PR TITLE
fix: 졸업 요건 분석 일자 courses 응답에서 받도록 수정

### DIFF
--- a/packages/client/src/entities/graduation/api/graduation.ts
+++ b/packages/client/src/entities/graduation/api/graduation.ts
@@ -288,10 +288,10 @@ export interface GraduationCourse {
 
 /** 이수 과목 조회 API 응답 */
 export interface GraduationCoursesResponse {
+  createdAt: string | null;
   courses: GraduationCourse[];
 }
 
 export async function fetchGraduationCourses(): Promise<GraduationCoursesResponse> {
-  const { value: courses } = await fetchJsonOnAPI<{ value: GraduationCourse[] }>('/api/graduation/courses');
-  return { courses };
+  return await fetchJsonOnAPI<GraduationCoursesResponse>('/api/graduation/courses');
 }

--- a/packages/client/src/features/graduation/model/useGraduationDashboard.ts
+++ b/packages/client/src/features/graduation/model/useGraduationDashboard.ts
@@ -1,13 +1,15 @@
 import { useMe } from '@/entities/user/model/useAuth';
-import { useGraduationCheck } from '@/entities/graduation/model/useGraduation';
+import { useGraduationCheck, useGraduationCourses } from '@/entities/graduation/model/useGraduation';
 
 export function useGraduationDashboard() {
   const userQuery = useMe();
   const graduationCheckQuery = useGraduationCheck();
+  const graduationCoursesQuery = useGraduationCourses();
 
   return {
     user: userQuery.data,
     graduationData: graduationCheckQuery.data,
+    analyzedAt: graduationCoursesQuery.data?.createdAt ?? null,
     isPending: userQuery.isPending || graduationCheckQuery.isPending,
     isLoading: userQuery.isLoading || graduationCheckQuery.isLoading,
     isError: userQuery.isError || graduationCheckQuery.isError,

--- a/packages/client/src/pages/graduation/GraduationDashboardPage.tsx
+++ b/packages/client/src/pages/graduation/GraduationDashboardPage.tsx
@@ -60,9 +60,14 @@ function GraduationDashboardPage() {
     majorScope: ScopeType;
   } | null>(null);
   const { activeTab, setActiveTab } = useMobileTabs('major');
-  const { user, graduationData, isPending, isError, error } = useGraduationDashboard();
+  const { user, graduationData, analyzedAt, isPending, isError, error } = useGraduationDashboard();
   const { data: criteriaCategories } = useCriteriaCategories();
-  const { isOpen: isFeedbackOpen, openMode: feedbackOpenMode, onClose: closeFeedback, open: openFeedback } = useFeedbackTrigger({
+  const {
+    isOpen: isFeedbackOpen,
+    openMode: feedbackOpenMode,
+    onClose: closeFeedback,
+    open: openFeedback,
+  } = useFeedbackTrigger({
     enabled: !isPending && !isError,
     isMobile,
     activeTab,
@@ -214,7 +219,6 @@ function GraduationDashboardPage() {
         <Banner deleteBanner={handleDeleteBanner}>
           본 서비스는 베타 버전으로, 분석 결과는 공식적인 효력을 갖지 않습니다. 오류 또는 개선 사항이 있으시면
           알려주시면 서비스 개선에 도움이 됩니다.{' '}
-
           <button className="text-blue-700 font-semibold underline" onClick={() => openFeedback('manual')}>
             오류 제보
           </button>
@@ -251,16 +255,18 @@ function GraduationDashboardPage() {
 
           <Flex justify="justify-between" align="items-center">
             <div></div>
-            
+
             <Flex justify="justify-end" align="items-center" gap="gap-2">
-              <span className="text-sm text-gray-400">
-                {new Date(graduationData.createdAt).toLocaleDateString('ko-KR', {
-                  year: 'numeric',
-                  month: 'long',
-                  day: 'numeric',
-                })}{' '}
-                분석
-              </span>
+              {analyzedAt && (
+                <span className="text-sm text-gray-400">
+                  {new Date(analyzedAt).toLocaleDateString('ko-KR', {
+                    year: 'numeric',
+                    month: 'long',
+                    day: 'numeric',
+                  })}{' '}
+                  분석
+                </span>
+              )}
               <div className="bg-white rounded-md">
                 <Button variant="outlined" size="medium" onClick={handleStartOverGraduationCheck}>
                   다시 검사하기

--- a/packages/mock-server/src/data/graduation/courses.ts
+++ b/packages/mock-server/src/data/graduation/courses.ts
@@ -427,8 +427,8 @@ const transferCourses: GraduationCourse[] = [
   },
 ];
 
-export const coursesDataByUserType: Record<UserType, { value: GraduationCourse[] }> = {
-  SINGLE: { value: singleCourses },
-  DOUBLE: { value: doubleCourses },
-  TRANSFER: { value: transferCourses },
+export const coursesDataByUserType: Record<UserType, { createdAt: string; courses: GraduationCourse[] }> = {
+  SINGLE: { createdAt: '2026-03-03T20:16:00.000000', courses: singleCourses },
+  DOUBLE: { createdAt: '2026-03-03T20:16:00.000000', courses: doubleCourses },
+  TRANSFER: { createdAt: '2026-03-03T20:16:00.000000', courses: transferCourses },
 };


### PR DESCRIPTION
## 작업 내용
### [QA-144]
- 졸업 요건 검사 일자를 `check` 응답이 아니라 `courses` 응답에서 받도록 수정
- courses 응답 스코프를 `value`에서 `courses`로 수정 

[courses 관련 API 명세](https://www.notion.so/315acf7c316280e4802fde269f6f5652?source=copy_link)
## 변경 사항 및 리뷰 포인트
