### PR TITLE
 feat: 관리자 페이지 공지 관리 기능 구현

### DIFF
--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -18,7 +18,9 @@
     "dexie": "^4.0.11",
     "dotenv": "^16.6.1",
     "react-datepicker": "^8.4.0",
-    "react-helmet": "^6.1.0"
+    "react-helmet": "^6.1.0",
+    "react-markdown": "^10.1.0",
+    "remark-gfm": "^4.0.1"
   },
   "devDependencies": {
     "@allcll/mock-server": "workspace:^",

--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -10,8 +10,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@allcll/common": "workspace:^",
     "@allcll/allcll-ui": "workspace:^",
+    "@allcll/common": "workspace:^",
     "@svgr/webpack": "^8.1.0",
     "@tanstack/react-query": "^5.83.0",
     "@vitejs/plugin-basic-ssl": "^2.1.0",
@@ -20,6 +20,7 @@
     "react-datepicker": "^8.4.0",
     "react-helmet": "^6.1.0",
     "react-markdown": "^10.1.0",
+    "remark-breaks": "^4.0.0",
     "remark-gfm": "^4.0.1"
   },
   "devDependencies": {

--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -20,7 +20,9 @@
     "dexie": "^4.0.11",
     "dotenv": "^16.6.1",
     "react-datepicker": "^8.4.0",
-    "react-helmet": "^6.1.0"
+    "react-helmet": "^6.1.0",
+    "react-markdown": "^10.1.0",
+    "remark-gfm": "^4.0.1"
   },
   "devDependencies": {
     "@allcll/mock-server": "workspace:^",

--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -10,18 +10,19 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@allcll/common": "workspace:^",
     "@allcll/allcll-ui": "workspace:^",
-    "chart.js": "^4.5.0",
-    "react-chartjs-2": "^5.3.0",
+    "@allcll/common": "workspace:^",
     "@svgr/webpack": "^8.1.0",
     "@tanstack/react-query": "^5.83.0",
     "@vitejs/plugin-basic-ssl": "^2.1.0",
+    "chart.js": "^4.5.0",
     "dexie": "^4.0.11",
     "dotenv": "^16.6.1",
+    "react-chartjs-2": "^5.3.0",
     "react-datepicker": "^8.4.0",
     "react-helmet": "^6.1.0",
     "react-markdown": "^10.1.0",
+    "remark-breaks": "^4.0.0",
     "remark-gfm": "^4.0.1"
   },
   "devDependencies": {

--- a/packages/admin/public/index.css
+++ b/packages/admin/public/index.css
@@ -8,3 +8,100 @@ body {
 :root {
   background-color: #f9fafb;
 }
+
+/* Markdown prose styles for notice editor preview */
+.prose {
+  color: #364153;
+  line-height: 1.75;
+}
+
+.prose h1,
+.prose h2 {
+  border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+  padding-bottom: 0.3em;
+  color: #202123;
+  font-weight: 600;
+}
+
+.prose h1 { font-size: 1.875rem; margin: 1rem 0 0.5rem; }
+.prose h2 { font-size: 1.5rem; margin: 1rem 0 0.5rem; }
+.prose h3 { font-size: 1.25rem; color: #202123; font-weight: 600; margin: 0.75rem 0 0.5rem; }
+
+.prose p { margin: 0.75rem 0; }
+
+.prose code {
+  background: #eff6ff;
+  color: #2563eb;
+  padding: 0.2em 0.4em;
+  border-radius: 0.25rem;
+  font-family: ui-monospace, monospace;
+  font-size: 0.875em;
+}
+
+.prose pre {
+  background: #f9fafb;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  border-radius: 0.5rem;
+  padding: 1rem;
+  overflow-x: auto;
+}
+
+.prose pre code {
+  background: none;
+  color: inherit;
+  padding: 0;
+  font-size: inherit;
+}
+
+.prose blockquote {
+  border-left: 4px solid #3b82f6;
+  padding-left: 1em;
+  color: #6b7280;
+  font-style: italic;
+  margin: 0.75rem 0;
+}
+
+.prose a {
+  color: #2563eb;
+  text-decoration: underline;
+}
+
+.prose ul {
+  list-style-type: disc;
+  padding-left: 1.5em;
+  margin: 0.5rem 0;
+}
+
+.prose ul ul {
+  list-style-type: circle;
+}
+
+.prose ul ul ul {
+  list-style-type: square;
+}
+
+.prose ol {
+  list-style-type: decimal;
+  padding-left: 1.5em;
+  margin: 0.5rem 0;
+}
+
+.prose li { margin: 0.25rem 0; }
+
+.prose table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 0.75rem 0;
+}
+
+.prose th,
+.prose td {
+  border: 1px solid #e5e7eb;
+  padding: 0.5rem 0.75rem;
+  text-align: left;
+}
+
+.prose th {
+  background: #f9fafb;
+  font-weight: 600;
+}

--- a/packages/admin/public/index.css
+++ b/packages/admin/public/index.css
@@ -39,8 +39,8 @@ body {
 }
 
 .prose pre {
-  background: #f9fafb;
-  border: 1px solid rgba(0, 0, 0, 0.1);
+  background: #f1f5f9;
+  border-left: 3px solid #3b82f6;
   border-radius: 0.5rem;
   padding: 1rem;
   overflow-x: auto;
@@ -48,7 +48,7 @@ body {
 
 .prose pre code {
   background: none;
-  color: inherit;
+  color: #2563eb;
   padding: 0;
   font-size: inherit;
 }

--- a/packages/admin/src/assets/alert-triangle.svg
+++ b/packages/admin/src/assets/alert-triangle.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3"/>
+  <path d="M12 9v4"/>
+  <path d="M12 17h.01"/>
+</svg>

--- a/packages/admin/src/assets/arrow-left.svg
+++ b/packages/admin/src/assets/arrow-left.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="m12 19-7-7 7-7"/>
+  <path d="M19 12H5"/>
+</svg>

--- a/packages/admin/src/assets/bold.svg
+++ b/packages/admin/src/assets/bold.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M6 12h9a4 4 0 0 1 0 8H7a1 1 0 0 1-1-1V5a1 1 0 0 1 1-1h7a4 4 0 0 1 0 8"/>
+</svg>

--- a/packages/admin/src/assets/code.svg
+++ b/packages/admin/src/assets/code.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="m16 18 6-6-6-6"/>
+  <path d="m8 6-6 6 6 6"/>
+</svg>

--- a/packages/admin/src/assets/edit.svg
+++ b/packages/admin/src/assets/edit.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M21.174 6.812a1 1 0 0 0-3.986-3.987L3.842 16.174a2 2 0 0 0-.5.83l-1.321 4.352a.5.5 0 0 0 .623.622l4.353-1.32a2 2 0 0 0 .83-.497z"/>
+</svg>

--- a/packages/admin/src/assets/file-text.svg
+++ b/packages/admin/src/assets/file-text.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z"/>
+  <path d="M14 2v4a2 2 0 0 0 2 2h4"/>
+  <path d="M10 9H8"/>
+  <path d="M16 13H8"/>
+  <path d="M16 17H8"/>
+</svg>

--- a/packages/admin/src/assets/italic.svg
+++ b/packages/admin/src/assets/italic.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <line x1="19" x2="10" y1="4" y2="4"/>
+  <line x1="14" x2="5" y1="20" y2="20"/>
+  <line x1="15" x2="9" y1="4" y2="20"/>
+</svg>

--- a/packages/admin/src/assets/link.svg
+++ b/packages/admin/src/assets/link.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/>
+  <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/>
+</svg>

--- a/packages/admin/src/assets/list-ordered.svg
+++ b/packages/admin/src/assets/list-ordered.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M10 12h11"/>
+  <path d="M10 18h11"/>
+  <path d="M10 6h11"/>
+  <path d="M4 10h2"/>
+  <path d="M4 6h1v4"/>
+  <path d="M6 18H4c0-1 2-2 2-3s-1-1.5-2-1"/>
+</svg>

--- a/packages/admin/src/assets/list.svg
+++ b/packages/admin/src/assets/list.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M3 12h.01"/>
+  <path d="M3 18h.01"/>
+  <path d="M3 6h.01"/>
+  <path d="M8 12h13"/>
+  <path d="M8 18h13"/>
+  <path d="M8 6h13"/>
+</svg>

--- a/packages/admin/src/assets/plus.svg
+++ b/packages/admin/src/assets/plus.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M5 12h14"/>
+  <path d="M12 5v14"/>
+</svg>

--- a/packages/admin/src/assets/quote.svg
+++ b/packages/admin/src/assets/quote.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <line x1="4" y1="6" x2="4" y2="18"/>
+  <line x1="8" y1="9" x2="20" y2="9"/>
+  <line x1="8" y1="14" x2="20" y2="14"/>
+</svg>

--- a/packages/admin/src/assets/save.svg
+++ b/packages/admin/src/assets/save.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M15.2 3a2 2 0 0 1 1.4.6l3.8 3.8a2 2 0 0 1 .6 1.4V19a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2z"/>
+  <path d="M17 21v-7a1 1 0 0 0-1-1H8a1 1 0 0 0-1 1v7"/>
+  <path d="M7 3v4a1 1 0 0 0 1 1h7"/>
+</svg>

--- a/packages/admin/src/assets/trash.svg
+++ b/packages/admin/src/assets/trash.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M3 6h18"/>
+  <path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6"/>
+  <path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"/>
+  <line x1="10" x2="10" y1="11" y2="17"/>
+  <line x1="14" x2="14" y1="11" y2="17"/>
+</svg>

--- a/packages/admin/src/components/SideNavBar.tsx
+++ b/packages/admin/src/components/SideNavBar.tsx
@@ -29,6 +29,10 @@ const Menus = [
     title: '사용자 후기',
     link: '/reviews',
   },
+  {
+    title: '공지사항',
+    link: '/notices',
+  },
 ];
 
 function SideNavBar() {

--- a/packages/admin/src/components/notices/MarkdownEditor.tsx
+++ b/packages/admin/src/components/notices/MarkdownEditor.tsx
@@ -1,6 +1,7 @@
 import { useRef, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import remarkBreaks from 'remark-breaks';
 import BoldSvg from '@/assets/bold.svg?react';
 import ItalicSvg from '@/assets/italic.svg?react';
 import CodeSvg from '@/assets/code.svg?react';
@@ -201,7 +202,7 @@ function MarkdownEditor({ content, onChange }: Props) {
           <div className="min-h-[480px] px-5 py-4">
             {content.trim() ? (
               <div className="prose max-w-none">
-                <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>
+                <ReactMarkdown remarkPlugins={[remarkGfm, remarkBreaks]}>{content}</ReactMarkdown>
               </div>
             ) : (
               <p className="text-sm text-gray-400 italic">미리보기할 내용이 없습니다.</p>

--- a/packages/admin/src/components/notices/MarkdownEditor.tsx
+++ b/packages/admin/src/components/notices/MarkdownEditor.tsx
@@ -1,0 +1,222 @@
+import { useRef, useState } from 'react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import BoldSvg from '@/assets/bold.svg?react';
+import ItalicSvg from '@/assets/italic.svg?react';
+import CodeSvg from '@/assets/code.svg?react';
+import LinkSvg from '@/assets/link.svg?react';
+import ListSvg from '@/assets/list.svg?react';
+import ListOrderedSvg from '@/assets/list-ordered.svg?react';
+import QuoteSvg from '@/assets/quote.svg?react';
+import { Label, Flex } from '@allcll/allcll-ui';
+import ToolbarButton from '@/components/notices/ToolbarButton';
+
+const MAX_LENGTH = 10000;
+const WARN_LENGTH = 9000;
+
+type Tab = 'write' | 'preview';
+
+interface Props {
+  content: string;
+  onChange: (value: string) => void;
+}
+
+function MarkdownEditor({ content, onChange }: Props) {
+  const [tab, setTab] = useState<Tab>('write');
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  const handleContentChange = (v: string) => {
+    if (v.length <= MAX_LENGTH) onChange(v);
+  };
+
+  const insertMarkdown = (before: string, after = '', placeholder = '', linePrefix = false) => {
+    const ta = textareaRef.current;
+    if (!ta) return;
+    const start = ta.selectionStart;
+    const end = ta.selectionEnd;
+
+    if (linePrefix) {
+      const lineStart = content.lastIndexOf('\n', start - 1) + 1;
+      const newContent = content.slice(0, lineStart) + before + content.slice(lineStart);
+      handleContentChange(newContent);
+      requestAnimationFrame(() => {
+        ta.focus();
+        ta.setSelectionRange(start + before.length, end + before.length);
+      });
+      return;
+    }
+
+    const selected = content.slice(start, end) || placeholder;
+    const newContent = content.slice(0, start) + before + selected + after + content.slice(end);
+    handleContentChange(newContent);
+    requestAnimationFrame(() => {
+      ta.focus();
+      ta.setSelectionRange(start + before.length, start + before.length + selected.length);
+    });
+  };
+
+  const charCount = content.length;
+  const charCountClass =
+    charCount > MAX_LENGTH
+      ? 'text-red-600 font-semibold'
+      : charCount > WARN_LENGTH
+        ? 'text-amber-600'
+        : 'text-gray-400';
+
+  return (
+    <Flex direction="flex-col" gap="gap-1.5">
+      <Label>내용</Label>
+
+      <div className="flex flex-col border border-gray-300 rounded-lg overflow-hidden">
+        {/* 탭 헤더 */}
+        <div className="flex border-b border-gray-200 bg-gray-50">
+          <button
+            type="button"
+            className={`px-4 py-2 text-sm font-medium transition-colors border-b-2 -mb-px ${
+              tab === 'write'
+                ? 'border-blue-500 text-blue-500 bg-white'
+                : 'border-transparent text-gray-500 hover:text-blue-500'
+            }`}
+            onClick={() => setTab('write')}
+          >
+            Write
+          </button>
+          <button
+            type="button"
+            className={`px-4 py-2 text-sm font-medium transition-colors border-b-2 -mb-px ${
+              tab === 'preview'
+                ? 'border-blue-500 text-blue-500 bg-white'
+                : 'border-transparent text-gray-500 hover:text-blue-500'
+            }`}
+            onClick={() => setTab('preview')}
+          >
+            Preview
+          </button>
+        </div>
+
+        {/* Write 탭 */}
+        {tab === 'write' && (
+          <>
+            {/* 툴바 */}
+            <div className="flex items-center gap-0.5 px-2 py-1.5 bg-gray-50 border-b border-gray-200">
+              <ToolbarButton title="굵게 (Bold)" onClick={() => insertMarkdown('**', '**')}>
+                <BoldSvg className="w-4 h-4" />
+              </ToolbarButton>
+              <ToolbarButton title="기울임 (Italic)" onClick={() => insertMarkdown('*', '*')}>
+                <ItalicSvg className="w-4 h-4" />
+              </ToolbarButton>
+              <div className="w-px h-4 bg-gray-300 mx-1" />
+              <ToolbarButton title="코드 (Code)" onClick={() => insertMarkdown('`', '`')}>
+                <CodeSvg className="w-4 h-4" />
+              </ToolbarButton>
+              <ToolbarButton title="링크 (Link)" onClick={() => insertMarkdown('[', '](url)')}>
+                <LinkSvg className="w-4 h-4" />
+              </ToolbarButton>
+              <div className="w-px h-4 bg-gray-300 mx-1" />
+              <ToolbarButton title="인용" onClick={() => insertMarkdown('> ', '', '', true)}>
+                <QuoteSvg className="w-4 h-4" />
+              </ToolbarButton>
+              <ToolbarButton title="목록" onClick={() => insertMarkdown('- ', '', '', true)}>
+                <ListSvg className="w-4 h-4" />
+              </ToolbarButton>
+              <ToolbarButton title="번호 목록" onClick={() => insertMarkdown('1. ', '', '', true)}>
+                <ListOrderedSvg className="w-4 h-4" />
+              </ToolbarButton>
+            </div>
+            <textarea
+              ref={textareaRef}
+              value={content}
+              onChange={e => handleContentChange(e.target.value)}
+              onKeyDown={e => {
+                const ta = e.currentTarget;
+                const start = ta.selectionStart;
+                const end = ta.selectionEnd;
+
+                if (e.key === 'Tab') {
+                  e.preventDefault();
+                  const newContent = content.slice(0, start) + '  ' + content.slice(end);
+                  handleContentChange(newContent);
+                  requestAnimationFrame(() => {
+                    ta.setSelectionRange(start + 2, start + 2);
+                  });
+                }
+
+                if (e.key === 'Enter') {
+                  const lineStart = content.lastIndexOf('\n', start - 1) + 1;
+                  const currentLine = content.slice(lineStart, start);
+
+                  const unorderedMatch = currentLine.match(/^(\s*)-\s/);
+                  const orderedMatch = currentLine.match(/^(\s*)(\d+)\.\s/);
+
+                  if (unorderedMatch) {
+                    const indent = unorderedMatch[1];
+                    const isEmptyItem = currentLine.trim() === '-';
+                    if (isEmptyItem) {
+                      e.preventDefault();
+                      const newContent = content.slice(0, lineStart) + content.slice(start);
+                      handleContentChange(newContent);
+                      requestAnimationFrame(() => {
+                        ta.setSelectionRange(lineStart, lineStart);
+                      });
+                    } else {
+                      e.preventDefault();
+                      const insertion = `\n${indent}- `;
+                      const newContent = content.slice(0, start) + insertion + content.slice(end);
+                      handleContentChange(newContent);
+                      requestAnimationFrame(() => {
+                        ta.setSelectionRange(start + insertion.length, start + insertion.length);
+                      });
+                    }
+                  } else if (orderedMatch) {
+                    const indent = orderedMatch[1];
+                    const num = parseInt(orderedMatch[2], 10);
+                    const isEmptyItem = currentLine.trim() === `${num}.`;
+                    if (isEmptyItem) {
+                      e.preventDefault();
+                      const newContent = content.slice(0, lineStart) + content.slice(start);
+                      handleContentChange(newContent);
+                      requestAnimationFrame(() => {
+                        ta.setSelectionRange(lineStart, lineStart);
+                      });
+                    } else {
+                      e.preventDefault();
+                      const insertion = `\n${indent}${num + 1}. `;
+                      const newContent = content.slice(0, start) + insertion + content.slice(end);
+                      handleContentChange(newContent);
+                      requestAnimationFrame(() => {
+                        ta.setSelectionRange(start + insertion.length, start + insertion.length);
+                      });
+                    }
+                  }
+                }
+              }}
+              placeholder="내용을 입력하세요..."
+              className="w-full px-4 py-3 text-sm text-gray-900 placeholder-gray-400 resize-none focus:outline-none leading-relaxed min-h-[480px]"
+            />
+          </>
+        )}
+
+        {/* Preview 탭 */}
+        {tab === 'preview' && (
+          <div className="min-h-[480px] px-5 py-4">
+            {content.trim() ? (
+              <div className="prose max-w-none">
+                <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>
+              </div>
+            ) : (
+              <p className="text-sm text-gray-400 italic">미리보기할 내용이 없습니다.</p>
+            )}
+          </div>
+        )}
+      </div>
+
+      <Flex align="items-center" justify="justify-end" className="text-xs">
+        <span className={charCountClass}>
+          {charCount.toLocaleString()} / {MAX_LENGTH.toLocaleString()}자
+        </span>
+      </Flex>
+    </Flex>
+  );
+}
+
+export default MarkdownEditor;

--- a/packages/admin/src/components/notices/MarkdownEditor.tsx
+++ b/packages/admin/src/components/notices/MarkdownEditor.tsx
@@ -17,12 +17,12 @@ const WARN_LENGTH = 900;
 
 type Tab = 'write' | 'preview';
 
-interface Props {
+interface IMarkdownEditorProps {
   content: string;
   onChange: (value: string) => void;
 }
 
-function MarkdownEditor({ content, onChange }: Props) {
+function MarkdownEditor({ content, onChange }: IMarkdownEditorProps) {
   const [tab, setTab] = useState<Tab>('write');
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 

--- a/packages/admin/src/components/notices/MarkdownEditor.tsx
+++ b/packages/admin/src/components/notices/MarkdownEditor.tsx
@@ -12,22 +12,21 @@ import QuoteSvg from '@/assets/quote.svg?react';
 import { Label, Flex } from '@allcll/allcll-ui';
 import ToolbarButton from '@/components/notices/ToolbarButton';
 
-const MAX_LENGTH = 1000;
-const WARN_LENGTH = 900;
-
 type Tab = 'write' | 'preview';
 
 interface IMarkdownEditorProps {
   content: string;
+  maxLength: number;
   onChange: (value: string) => void;
 }
 
-function MarkdownEditor({ content, onChange }: IMarkdownEditorProps) {
+function MarkdownEditor({ content, maxLength, onChange }: IMarkdownEditorProps) {
   const [tab, setTab] = useState<Tab>('write');
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const warnLength = Math.floor(maxLength * 0.9);
 
   const handleContentChange = (v: string) => {
-    if (v.length <= MAX_LENGTH) onChange(v);
+    if (v.length <= maxLength) onChange(v);
   };
 
   const insertMarkdown = (before: string, after = '', placeholder = '', linePrefix = false) => {
@@ -58,11 +57,7 @@ function MarkdownEditor({ content, onChange }: IMarkdownEditorProps) {
 
   const charCount = content.length;
   const charCountClass =
-    charCount > MAX_LENGTH
-      ? 'text-red-600 font-semibold'
-      : charCount > WARN_LENGTH
-        ? 'text-amber-600'
-        : 'text-gray-400';
+    charCount > maxLength ? 'text-red-600 font-semibold' : charCount > warnLength ? 'text-amber-600' : 'text-gray-400';
 
   return (
     <Flex direction="flex-col" gap="gap-1.5">
@@ -213,7 +208,7 @@ function MarkdownEditor({ content, onChange }: IMarkdownEditorProps) {
 
       <Flex align="items-center" justify="justify-end" className="text-xs">
         <span className={charCountClass}>
-          {charCount.toLocaleString()} / {MAX_LENGTH.toLocaleString()}자
+          {charCount.toLocaleString()} / {maxLength.toLocaleString()}자
         </span>
       </Flex>
     </Flex>

--- a/packages/admin/src/components/notices/MarkdownEditor.tsx
+++ b/packages/admin/src/components/notices/MarkdownEditor.tsx
@@ -12,8 +12,8 @@ import QuoteSvg from '@/assets/quote.svg?react';
 import { Label, Flex } from '@allcll/allcll-ui';
 import ToolbarButton from '@/components/notices/ToolbarButton';
 
-const MAX_LENGTH = 10000;
-const WARN_LENGTH = 9000;
+const MAX_LENGTH = 1000;
+const WARN_LENGTH = 900;
 
 type Tab = 'write' | 'preview';
 

--- a/packages/admin/src/components/notices/NoticeDeleteModal.tsx
+++ b/packages/admin/src/components/notices/NoticeDeleteModal.tsx
@@ -1,4 +1,3 @@
-import { format } from 'date-fns';
 import { Button, Dialog, Flex } from '@allcll/allcll-ui';
 import { CATEGORY_LABELS, type Notice } from '@/hooks/server/useAdminNotices';
 
@@ -17,7 +16,7 @@ function NoticeDeleteModal({ notice, onCancel, onConfirm, isDeleting }: Props) {
           <div className="bg-gray-50 rounded-lg p-4 flex flex-col gap-1 text-sm">
             <p className="font-medium text-gray-900 line-clamp-2">{notice.title}</p>
             <p className="text-gray-500">
-              {CATEGORY_LABELS[notice.category]} · {format(new Date(notice.createdAt), 'yyyy.MM.dd')}
+              {CATEGORY_LABELS[notice.category]} · {notice.createdAt.slice(0, 10).replace(/-/g, '.')}
             </p>
           </div>
           <p className="text-sm text-gray-600">이 공지사항을 삭제하시겠습니까? 삭제 후 복구할 수 없습니다.</p>

--- a/packages/admin/src/components/notices/NoticeDeleteModal.tsx
+++ b/packages/admin/src/components/notices/NoticeDeleteModal.tsx
@@ -1,0 +1,38 @@
+import { format } from 'date-fns';
+import { Button, Dialog, Flex } from '@allcll/allcll-ui';
+import { CATEGORY_LABELS, type Notice } from '@/hooks/server/useAdminNotices';
+
+interface Props {
+  notice: Notice;
+  onCancel: () => void;
+  onConfirm: () => void;
+  isDeleting: boolean;
+}
+
+function NoticeDeleteModal({ notice, onCancel, onConfirm, isDeleting }: Props) {
+  return (
+    <Dialog title="공지사항 삭제" onClose={onCancel}>
+      <Dialog.Content>
+        <Flex direction="flex-col" gap="gap-3">
+          <div className="bg-gray-50 rounded-lg p-4 flex flex-col gap-1 text-sm">
+            <p className="font-medium text-gray-900 line-clamp-2">{notice.title}</p>
+            <p className="text-gray-500">
+              {CATEGORY_LABELS[notice.category]} · {format(new Date(notice.createdAt), 'yyyy.MM.dd')}
+            </p>
+          </div>
+          <p className="text-sm text-gray-600">이 공지사항을 삭제하시겠습니까? 삭제 후 복구할 수 없습니다.</p>
+        </Flex>
+      </Dialog.Content>
+      <Dialog.Footer>
+        <Button variant="outlined" size="small" onClick={onCancel} disabled={isDeleting}>
+          취소
+        </Button>
+        <Button variant="danger" size="small" onClick={onConfirm} disabled={isDeleting}>
+          {isDeleting ? '삭제 중...' : '삭제하기'}
+        </Button>
+      </Dialog.Footer>
+    </Dialog>
+  );
+}
+
+export default NoticeDeleteModal;

--- a/packages/admin/src/components/notices/NoticeDeleteModal.tsx
+++ b/packages/admin/src/components/notices/NoticeDeleteModal.tsx
@@ -1,5 +1,6 @@
 import { Button, Dialog, Flex } from '@allcll/allcll-ui';
-import { CATEGORY_LABELS, type Notice } from '@/hooks/server/useAdminNotices';
+import { CATEGORY_LABELS } from '@/hooks/server/useAdminNotices';
+import type { Notice } from '@/hooks/server/useAdminNotices';
 
 interface INoticeDeleteModalProps {
   notice: Notice;

--- a/packages/admin/src/components/notices/NoticeDeleteModal.tsx
+++ b/packages/admin/src/components/notices/NoticeDeleteModal.tsx
@@ -16,7 +16,7 @@ function NoticeDeleteModal({ notice, onCancel, onConfirm, isDeleting }: Props) {
           <div className="bg-gray-50 rounded-lg p-4 flex flex-col gap-1 text-sm">
             <p className="font-medium text-gray-900 line-clamp-2">{notice.title}</p>
             <p className="text-gray-500">
-              {CATEGORY_LABELS[notice.category]} · {notice.createdAt.slice(0, 10).replace(/-/g, '.')}
+              {CATEGORY_LABELS[notice.operationType]} · {notice.createdAt.slice(0, 10).replace(/-/g, '.')}
             </p>
           </div>
           <p className="text-sm text-gray-600">이 공지사항을 삭제하시겠습니까? 삭제 후 복구할 수 없습니다.</p>

--- a/packages/admin/src/components/notices/NoticeDeleteModal.tsx
+++ b/packages/admin/src/components/notices/NoticeDeleteModal.tsx
@@ -1,14 +1,14 @@
 import { Button, Dialog, Flex } from '@allcll/allcll-ui';
 import { CATEGORY_LABELS, type Notice } from '@/hooks/server/useAdminNotices';
 
-interface Props {
+interface INoticeDeleteModalProps {
   notice: Notice;
   onCancel: () => void;
   onConfirm: () => void;
   isDeleting: boolean;
 }
 
-function NoticeDeleteModal({ notice, onCancel, onConfirm, isDeleting }: Props) {
+function NoticeDeleteModal({ notice, onCancel, onConfirm, isDeleting }: INoticeDeleteModalProps) {
   return (
     <Dialog title="공지사항 삭제" onClose={onCancel}>
       <Dialog.Content>

--- a/packages/admin/src/components/notices/NoticeTable.tsx
+++ b/packages/admin/src/components/notices/NoticeTable.tsx
@@ -1,4 +1,3 @@
-import { format } from 'date-fns';
 import EditSvg from '@/assets/edit.svg?react';
 import TrashSvg from '@/assets/trash.svg?react';
 import FileTextSvg from '@/assets/file-text.svg?react';
@@ -68,7 +67,7 @@ function NoticeTable({ notices, isLoading, isError, onView, onEdit, onDelete }: 
                     {notice.title}
                   </td>
                   <td className="px-4 py-3 text-sm text-gray-500">
-                    {format(new Date(notice.createdAt), 'yyyy.MM.dd')}
+                    {notice.createdAt.slice(0, 10).replace(/-/g, '.')}
                   </td>
                   <td className="px-4 py-3">
                     <Flex align="items-center" gap="gap-1">

--- a/packages/admin/src/components/notices/NoticeTable.tsx
+++ b/packages/admin/src/components/notices/NoticeTable.tsx
@@ -1,0 +1,100 @@
+import { format } from 'date-fns';
+import EditSvg from '@/assets/edit.svg?react';
+import TrashSvg from '@/assets/trash.svg?react';
+import FileTextSvg from '@/assets/file-text.svg?react';
+import { Card, SupportingText, Badge, IconButton, Flex } from '@allcll/allcll-ui';
+import { CATEGORY_LABELS, type Notice } from '@/hooks/server/useAdminNotices';
+
+interface Props {
+  notices: Notice[];
+  isLoading: boolean;
+  isError: boolean;
+  onView: (notice: Notice) => void;
+  onEdit: (notice: Notice) => void;
+  onDelete: (notice: Notice) => void;
+}
+
+function NoticeTable({ notices, isLoading, isError, onView, onEdit, onDelete }: Props) {
+  return (
+    <Card className="overflow-hidden flex flex-col flex-1 min-h-0">
+      <div className="overflow-y-auto flex-1">
+        <table className="w-full border-collapse table-fixed">
+          <thead className="sticky top-0 z-10">
+            <tr className="bg-gray-50 text-sm text-gray-500">
+              <th className="text-left px-4 py-2 font-medium w-28">카테고리</th>
+              <th className="text-left px-4 py-2 font-medium">제목</th>
+              <th className="text-left px-4 py-2 font-medium w-28">작성일</th>
+              <th className="w-24" />
+            </tr>
+          </thead>
+          <tbody>
+            {isLoading && (
+              <tr>
+                <td colSpan={4} className="py-8 text-center">
+                  <SupportingText>불러오는 중...</SupportingText>
+                </td>
+              </tr>
+            )}
+            {!isLoading && isError && (
+              <tr>
+                <td colSpan={4} className="py-8 text-center text-sm text-red-500">
+                  공지사항을 불러오는데 실패했습니다.
+                </td>
+              </tr>
+            )}
+            {!isLoading && !isError && notices.length === 0 && (
+              <tr>
+                <td colSpan={4} className="py-12 text-center">
+                  <Flex direction="flex-col" align="items-center" gap="gap-2" className="text-gray-400">
+                    <FileTextSvg className="w-8 h-8" />
+                    <SupportingText>공지사항이 없습니다.</SupportingText>
+                  </Flex>
+                </td>
+              </tr>
+            )}
+            {!isLoading &&
+              !isError &&
+              notices.map(notice => (
+                <tr key={notice.id} className="border-t border-gray-100 hover:bg-gray-50 transition-colors">
+                  <td className="px-4 py-3">
+                    <Badge variant="primary" size="small">
+                      {CATEGORY_LABELS[notice.category]}
+                    </Badge>
+                  </td>
+                  <td
+                    className="px-4 py-3 text-sm text-gray-900 truncate cursor-pointer hover:text-blue-500 transition-colors"
+                    onClick={() => onView(notice)}
+                  >
+                    {notice.title}
+                  </td>
+                  <td className="px-4 py-3 text-sm text-gray-500">
+                    {format(new Date(notice.createdAt), 'yyyy.MM.dd')}
+                  </td>
+                  <td className="px-4 py-3">
+                    <Flex align="items-center" gap="gap-1">
+                      <IconButton
+                        icon={<EditSvg className="w-4 h-4" />}
+                        label="수정"
+                        variant="plain"
+                        onClick={() => onEdit(notice)}
+                        className="p-1.5 text-gray-400 hover:text-blue-500 hover:bg-blue-50 transition-colors"
+                      />
+                      <IconButton
+                        icon={<TrashSvg className="w-4 h-4" />}
+                        label="삭제"
+                        variant="plain"
+                        onClick={() => onDelete(notice)}
+                        className="p-1.5 text-gray-400 hover:text-red-500 hover:bg-red-50 transition-colors"
+                      />
+                    </Flex>
+                  </td>
+                </tr>
+              ))}
+          </tbody>
+        </table>
+      </div>
+    </Card>
+  );
+}
+
+export default NoticeTable;

--- a/packages/admin/src/components/notices/NoticeTable.tsx
+++ b/packages/admin/src/components/notices/NoticeTable.tsx
@@ -22,7 +22,7 @@ function NoticeTable({ notices, isLoading, isError, onView, onEdit, onDelete }: 
             <tr className="bg-gray-50 text-sm text-gray-500">
               <th className="text-left px-4 py-2 font-medium w-28">카테고리</th>
               <th className="text-left px-4 py-2 font-medium">제목</th>
-              <th className="text-left px-4 py-2 font-medium w-28">작성일</th>
+              <th className="text-left px-4 py-2 font-medium w-32">날짜</th>
               <th className="w-24" />
             </tr>
           </thead>
@@ -66,8 +66,13 @@ function NoticeTable({ notices, isLoading, isError, onView, onEdit, onDelete }: 
                   >
                     {notice.title}
                   </td>
-                  <td className="px-4 py-3 text-sm text-gray-500">
-                    {notice.createdAt.slice(0, 10).replace(/-/g, '.')}
+                  <td className="px-4 py-3 text-sm text-gray-500 whitespace-nowrap">
+                    <div>{notice.updatedAt.slice(0, 10).replace(/-/g, '.')}</div>
+                    {notice.updatedAt !== notice.createdAt && (
+                      <div className="text-xs text-gray-400">
+                        작성 {notice.createdAt.slice(0, 10).replace(/-/g, '.')}
+                      </div>
+                    )}
                   </td>
                   <td className="px-4 py-3">
                     <Flex align="items-center" gap="gap-1">

--- a/packages/admin/src/components/notices/NoticeTable.tsx
+++ b/packages/admin/src/components/notices/NoticeTable.tsx
@@ -4,7 +4,7 @@ import FileTextSvg from '@/assets/file-text.svg?react';
 import { Card, SupportingText, Badge, IconButton, Flex } from '@allcll/allcll-ui';
 import { CATEGORY_LABELS, type Notice } from '@/hooks/server/useAdminNotices';
 
-interface Props {
+interface INoticeTableProps {
   notices: Notice[];
   isLoading: boolean;
   isError: boolean;
@@ -13,7 +13,7 @@ interface Props {
   onDelete: (notice: Notice) => void;
 }
 
-function NoticeTable({ notices, isLoading, isError, onView, onEdit, onDelete }: Props) {
+function NoticeTable({ notices, isLoading, isError, onView, onEdit, onDelete }: INoticeTableProps) {
   return (
     <Card className="overflow-hidden flex flex-col flex-1 min-h-0">
       <div className="overflow-y-auto flex-1">

--- a/packages/admin/src/components/notices/NoticeTable.tsx
+++ b/packages/admin/src/components/notices/NoticeTable.tsx
@@ -2,7 +2,8 @@ import EditSvg from '@/assets/edit.svg?react';
 import TrashSvg from '@/assets/trash.svg?react';
 import FileTextSvg from '@/assets/file-text.svg?react';
 import { Card, SupportingText, Badge, IconButton, Flex } from '@allcll/allcll-ui';
-import { CATEGORY_LABELS, type Notice } from '@/hooks/server/useAdminNotices';
+import { CATEGORY_LABELS } from '@/hooks/server/useAdminNotices';
+import type { Notice } from '@/hooks/server/useAdminNotices';
 
 interface INoticeTableProps {
   notices: Notice[];

--- a/packages/admin/src/components/notices/NoticeTable.tsx
+++ b/packages/admin/src/components/notices/NoticeTable.tsx
@@ -22,7 +22,7 @@ function NoticeTable({ notices, isLoading, isError, onView, onEdit, onDelete }: 
             <tr className="bg-gray-50 text-sm text-gray-500">
               <th className="text-left px-4 py-2 font-medium w-28">카테고리</th>
               <th className="text-left px-4 py-2 font-medium">제목</th>
-              <th className="text-left px-4 py-2 font-medium w-32">날짜</th>
+              <th className="text-left px-4 py-2 font-medium w-32">작성일</th>
               <th className="w-24" />
             </tr>
           </thead>
@@ -75,12 +75,7 @@ function NoticeTable({ notices, isLoading, isError, onView, onEdit, onDelete }: 
                     {notice.title}
                   </td>
                   <td className="px-4 py-3 text-sm text-gray-500 whitespace-nowrap">
-                    <div>{notice.updatedAt.slice(0, 10).replace(/-/g, '.')}</div>
-                    {notice.updatedAt !== notice.createdAt && (
-                      <div className="text-xs text-gray-400">
-                        작성 {notice.createdAt.slice(0, 10).replace(/-/g, '.')}
-                      </div>
-                    )}
+                    {notice.createdAt.slice(0, 10).replace(/-/g, '.')}
                   </td>
                   <td className="px-4 py-3">
                     <Flex align="items-center" gap="gap-1">

--- a/packages/admin/src/components/notices/NoticeTable.tsx
+++ b/packages/admin/src/components/notices/NoticeTable.tsx
@@ -62,7 +62,15 @@ function NoticeTable({ notices, isLoading, isError, onView, onEdit, onDelete }: 
                   </td>
                   <td
                     className="px-4 py-3 text-sm text-gray-900 truncate cursor-pointer hover:text-blue-500 transition-colors"
+                    role="button"
+                    tabIndex={0}
                     onClick={() => onView(notice)}
+                    onKeyDown={e => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault();
+                        onView(notice);
+                      }
+                    }}
                   >
                     {notice.title}
                   </td>

--- a/packages/admin/src/components/notices/NoticeTable.tsx
+++ b/packages/admin/src/components/notices/NoticeTable.tsx
@@ -57,7 +57,7 @@ function NoticeTable({ notices, isLoading, isError, onView, onEdit, onDelete }: 
                 <tr key={notice.id} className="border-t border-gray-100 hover:bg-gray-50 transition-colors">
                   <td className="px-4 py-3">
                     <Badge variant="primary" size="small">
-                      {CATEGORY_LABELS[notice.category]}
+                      {CATEGORY_LABELS[notice.operationType]}
                     </Badge>
                   </td>
                   <td

--- a/packages/admin/src/components/notices/NoticeViewModal.tsx
+++ b/packages/admin/src/components/notices/NoticeViewModal.tsx
@@ -1,0 +1,41 @@
+import { format } from 'date-fns';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import { Button, Dialog, Badge, Flex } from '@allcll/allcll-ui';
+import { CATEGORY_LABELS, type Notice } from '@/hooks/server/useAdminNotices';
+
+interface Props {
+  notice: Notice;
+  onClose: () => void;
+  onEdit: () => void;
+}
+
+function NoticeViewModal({ notice, onClose, onEdit }: Props) {
+  return (
+    <Dialog title={notice.title} onClose={onClose}>
+      <Dialog.Content>
+        <Flex direction="flex-col" gap="gap-4" className="w-[640px] max-w-full">
+          <Flex align="items-center" gap="gap-2" className="text-xs text-gray-500">
+            <Badge variant="primary" size="small">
+              {CATEGORY_LABELS[notice.category]}
+            </Badge>
+            <span>{format(new Date(notice.createdAt), 'yyyy.MM.dd')}</span>
+          </Flex>
+          <div className="prose max-w-none max-h-[60vh] overflow-y-auto pr-1">
+            <ReactMarkdown remarkPlugins={[remarkGfm]}>{notice.content}</ReactMarkdown>
+          </div>
+        </Flex>
+      </Dialog.Content>
+      <Dialog.Footer>
+        <Button variant="outlined" size="small" onClick={onClose}>
+          닫기
+        </Button>
+        <Button variant="primary" size="small" onClick={onEdit}>
+          수정하기
+        </Button>
+      </Dialog.Footer>
+    </Dialog>
+  );
+}
+
+export default NoticeViewModal;

--- a/packages/admin/src/components/notices/NoticeViewModal.tsx
+++ b/packages/admin/src/components/notices/NoticeViewModal.tsx
@@ -1,5 +1,6 @@
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import remarkBreaks from 'remark-breaks';
 import { Button, Dialog, Badge, Flex } from '@allcll/allcll-ui';
 import { CATEGORY_LABELS, type Notice } from '@/hooks/server/useAdminNotices';
 
@@ -21,7 +22,7 @@ function NoticeViewModal({ notice, onClose, onEdit }: Props) {
             <span>{notice.createdAt.slice(0, 10).replace(/-/g, '.')}</span>
           </Flex>
           <div className="prose max-w-none max-h-[60vh] overflow-y-auto pr-1">
-            <ReactMarkdown remarkPlugins={[remarkGfm]}>{notice.content}</ReactMarkdown>
+            <ReactMarkdown remarkPlugins={[remarkGfm, remarkBreaks]}>{notice.content}</ReactMarkdown>
           </div>
         </Flex>
       </Dialog.Content>

--- a/packages/admin/src/components/notices/NoticeViewModal.tsx
+++ b/packages/admin/src/components/notices/NoticeViewModal.tsx
@@ -1,4 +1,3 @@
-import { format } from 'date-fns';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { Button, Dialog, Badge, Flex } from '@allcll/allcll-ui';
@@ -19,7 +18,7 @@ function NoticeViewModal({ notice, onClose, onEdit }: Props) {
             <Badge variant="primary" size="small">
               {CATEGORY_LABELS[notice.category]}
             </Badge>
-            <span>{format(new Date(notice.createdAt), 'yyyy.MM.dd')}</span>
+            <span>{notice.createdAt.slice(0, 10).replace(/-/g, '.')}</span>
           </Flex>
           <div className="prose max-w-none max-h-[60vh] overflow-y-auto pr-1">
             <ReactMarkdown remarkPlugins={[remarkGfm]}>{notice.content}</ReactMarkdown>

--- a/packages/admin/src/components/notices/NoticeViewModal.tsx
+++ b/packages/admin/src/components/notices/NoticeViewModal.tsx
@@ -14,12 +14,15 @@ function NoticeViewModal({ notice, onClose, onEdit }: Props) {
   return (
     <Dialog title={notice.title} onClose={onClose}>
       <Dialog.Content>
-        <Flex direction="flex-col" gap="gap-4" className="w-[640px] max-w-full">
+        <Flex direction="flex-col" gap="gap-4" className="w-160 max-w-full">
           <Flex align="items-center" gap="gap-2" className="text-xs text-gray-500">
             <Badge variant="primary" size="small">
               {CATEGORY_LABELS[notice.operationType]}
             </Badge>
-            <span>{notice.createdAt.slice(0, 10).replace(/-/g, '.')}</span>
+            <span>{notice.updatedAt.slice(0, 10).replace(/-/g, '.')}</span>
+            {notice.updatedAt !== notice.createdAt && (
+              <span className="text-gray-400">· 작성 {notice.createdAt.slice(0, 10).replace(/-/g, '.')}</span>
+            )}
           </Flex>
           <div className="prose max-w-none max-h-[60vh] overflow-y-auto pr-1">
             <ReactMarkdown remarkPlugins={[remarkGfm, remarkBreaks]}>{notice.content}</ReactMarkdown>

--- a/packages/admin/src/components/notices/NoticeViewModal.tsx
+++ b/packages/admin/src/components/notices/NoticeViewModal.tsx
@@ -19,9 +19,9 @@ function NoticeViewModal({ notice, onClose, onEdit }: Props) {
             <Badge variant="primary" size="small">
               {CATEGORY_LABELS[notice.operationType]}
             </Badge>
-            <span>{notice.updatedAt.slice(0, 10).replace(/-/g, '.')}</span>
-            {notice.updatedAt !== notice.createdAt && (
-              <span className="text-gray-400">· 작성 {notice.createdAt.slice(0, 10).replace(/-/g, '.')}</span>
+            <span>작성 {notice.createdAt.slice(0, 10).replace(/-/g, '.')}</span>
+            {notice.updatedAt.slice(0, 10) !== notice.createdAt.slice(0, 10) && (
+              <span className="text-gray-400">· 수정 {notice.updatedAt.slice(0, 10).replace(/-/g, '.')}</span>
             )}
           </Flex>
           <div className="prose max-w-none max-h-[60vh] overflow-y-auto pr-1">

--- a/packages/admin/src/components/notices/NoticeViewModal.tsx
+++ b/packages/admin/src/components/notices/NoticeViewModal.tsx
@@ -4,13 +4,13 @@ import remarkBreaks from 'remark-breaks';
 import { Button, Dialog, Badge, Flex } from '@allcll/allcll-ui';
 import { CATEGORY_LABELS, type Notice } from '@/hooks/server/useAdminNotices';
 
-interface Props {
+interface INoticeViewModalProps {
   notice: Notice;
   onClose: () => void;
   onEdit: () => void;
 }
 
-function NoticeViewModal({ notice, onClose, onEdit }: Props) {
+function NoticeViewModal({ notice, onClose, onEdit }: INoticeViewModalProps) {
   return (
     <Dialog title={notice.title} onClose={onClose}>
       <Dialog.Content>

--- a/packages/admin/src/components/notices/NoticeViewModal.tsx
+++ b/packages/admin/src/components/notices/NoticeViewModal.tsx
@@ -2,7 +2,8 @@ import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import remarkBreaks from 'remark-breaks';
 import { Button, Dialog, Badge, Flex } from '@allcll/allcll-ui';
-import { CATEGORY_LABELS, type Notice } from '@/hooks/server/useAdminNotices';
+import { CATEGORY_LABELS } from '@/hooks/server/useAdminNotices';
+import type { Notice } from '@/hooks/server/useAdminNotices';
 
 interface INoticeViewModalProps {
   notice: Notice;

--- a/packages/admin/src/components/notices/NoticeViewModal.tsx
+++ b/packages/admin/src/components/notices/NoticeViewModal.tsx
@@ -17,7 +17,7 @@ function NoticeViewModal({ notice, onClose, onEdit }: Props) {
         <Flex direction="flex-col" gap="gap-4" className="w-[640px] max-w-full">
           <Flex align="items-center" gap="gap-2" className="text-xs text-gray-500">
             <Badge variant="primary" size="small">
-              {CATEGORY_LABELS[notice.category]}
+              {CATEGORY_LABELS[notice.operationType]}
             </Badge>
             <span>{notice.createdAt.slice(0, 10).replace(/-/g, '.')}</span>
           </Flex>

--- a/packages/admin/src/components/notices/ToolbarButton.tsx
+++ b/packages/admin/src/components/notices/ToolbarButton.tsx
@@ -1,0 +1,21 @@
+import { IconButton } from '@allcll/allcll-ui';
+
+interface Props {
+  onClick: () => void;
+  title: string;
+  children: React.ReactNode;
+}
+
+function ToolbarButton({ onClick, title, children }: Props) {
+  return (
+    <IconButton
+      icon={children}
+      label={title}
+      variant="plain"
+      onClick={onClick}
+      className="p-1.5 text-gray-500 hover:text-gray-800 hover:bg-gray-200 transition-colors"
+    />
+  );
+}
+
+export default ToolbarButton;

--- a/packages/admin/src/components/notices/ToolbarButton.tsx
+++ b/packages/admin/src/components/notices/ToolbarButton.tsx
@@ -1,12 +1,12 @@
 import { IconButton } from '@allcll/allcll-ui';
 
-interface Props {
+interface IToolbarButtonProps {
   onClick: () => void;
   title: string;
   children: React.ReactNode;
 }
 
-function ToolbarButton({ onClick, title, children }: Props) {
+function ToolbarButton({ onClick, title, children }: IToolbarButtonProps) {
   return (
     <IconButton
       icon={children}

--- a/packages/admin/src/components/notices/UnsavedModal.tsx
+++ b/packages/admin/src/components/notices/UnsavedModal.tsx
@@ -1,0 +1,35 @@
+import AlertTriangleSvg from '@/assets/alert-triangle.svg?react';
+import { Button, Dialog, Flex } from '@allcll/allcll-ui';
+
+interface Props {
+  onCancel: () => void;
+  onConfirm: () => void;
+}
+
+function UnsavedModal({ onCancel, onConfirm }: Props) {
+  return (
+    <Dialog title="저장되지 않은 변경사항" onClose={onCancel}>
+      <Dialog.Content>
+        <Flex gap="gap-3">
+          <div className="flex-shrink-0 flex items-center justify-center w-10 h-10 rounded-full bg-amber-100">
+            <AlertTriangleSvg className="w-5 h-5 text-amber-500" />
+          </div>
+          <Flex direction="flex-col" gap="gap-1">
+            <p className="text-sm font-medium text-gray-800">작성 중인 내용이 있습니다.</p>
+            <p className="text-sm text-gray-500">페이지를 나가면 작성 중인 내용이 사라집니다. 계속 하시겠습니까?</p>
+          </Flex>
+        </Flex>
+      </Dialog.Content>
+      <Dialog.Footer>
+        <Button variant="primary" size="small" onClick={onCancel}>
+          계속 작성
+        </Button>
+        <Button variant="outlined" size="small" onClick={onConfirm}>
+          나가기
+        </Button>
+      </Dialog.Footer>
+    </Dialog>
+  );
+}
+
+export default UnsavedModal;

--- a/packages/admin/src/components/notices/UnsavedModal.tsx
+++ b/packages/admin/src/components/notices/UnsavedModal.tsx
@@ -1,12 +1,12 @@
 import AlertTriangleSvg from '@/assets/alert-triangle.svg?react';
 import { Button, Dialog, Flex } from '@allcll/allcll-ui';
 
-interface Props {
+interface IUnsavedModalProps {
   onCancel: () => void;
   onConfirm: () => void;
 }
 
-function UnsavedModal({ onCancel, onConfirm }: Props) {
+function UnsavedModal({ onCancel, onConfirm }: IUnsavedModalProps) {
   return (
     <Dialog title="저장되지 않은 변경사항" onClose={onCancel}>
       <Dialog.Content>

--- a/packages/admin/src/hooks/server/useAdminNotices.ts
+++ b/packages/admin/src/hooks/server/useAdminNotices.ts
@@ -1,0 +1,114 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { fetchJsonOnAPI, fetchDeleteJsonOnAPI } from '@/utils/api';
+
+export interface Notice {
+  id: number;
+  title: string;
+  content: string;
+  category: NoticeCategory;
+  createdAt: string;
+}
+
+export type NoticeCategory =
+  | 'SERVICE'
+  | 'GRADUATION'
+  | 'TIMETABLE'
+  | 'REALTIME'
+  | 'COURSE_ANALYSIS'
+  | 'SIMULATION'
+  | 'WISHLIST';
+
+export type NoticeCategoryAll = NoticeCategory | 'ALL';
+
+export const CATEGORY_LABELS: Record<NoticeCategoryAll, string> = {
+  ALL: '전체',
+  SERVICE: '서비스',
+  GRADUATION: '졸업요건',
+  TIMETABLE: '시간표',
+  REALTIME: '실시간 여석',
+  COURSE_ANALYSIS: '과목분석',
+  SIMULATION: '수강신청 연습',
+  WISHLIST: '관심과목',
+};
+
+export const NOTICE_CATEGORIES: NoticeCategory[] = [
+  'SERVICE',
+  'GRADUATION',
+  'TIMETABLE',
+  'REALTIME',
+  'COURSE_ANALYSIS',
+  'SIMULATION',
+  'WISHLIST',
+];
+
+interface NoticesResponse {
+  notices: Notice[];
+}
+
+const NOTICES_QUERY_KEY = ['admin', 'notices'];
+
+// GET /api/admin/notices
+export function useAdminNotices() {
+  return useQuery<NoticesResponse, Error, Notice[]>({
+    queryKey: NOTICES_QUERY_KEY,
+    queryFn: () => fetchJsonOnAPI<NoticesResponse>('/api/admin/notices'),
+    select: data => data.notices,
+  });
+}
+
+// 목록 캐시에서 단건 조회
+export function useAdminNotice(id: number | undefined) {
+  return useQuery<NoticesResponse, Error, Notice | undefined>({
+    queryKey: NOTICES_QUERY_KEY,
+    queryFn: () => fetchJsonOnAPI<NoticesResponse>('/api/admin/notices'),
+    select: data => data.notices.find(n => n.id === id),
+    enabled: id !== undefined,
+  });
+}
+
+interface NoticePayload {
+  title: string;
+  content: string;
+  category: NoticeCategory;
+}
+
+// POST /api/admin/notices
+export function useCreateNotice() {
+  const queryClient = useQueryClient();
+  return useMutation<Notice, Error, NoticePayload>({
+    mutationFn: payload =>
+      fetchJsonOnAPI<Notice>('/api/admin/notices', {
+        method: 'POST',
+        body: JSON.stringify(payload),
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: NOTICES_QUERY_KEY });
+    },
+  });
+}
+
+// PATCH /api/admin/notices/:id
+export function useUpdateNotice(id: number) {
+  const queryClient = useQueryClient();
+  return useMutation<Notice, Error, NoticePayload>({
+    mutationFn: payload =>
+      fetchJsonOnAPI<Notice>(`/api/admin/notices/${id}`, {
+        method: 'PATCH',
+        body: JSON.stringify(payload),
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: NOTICES_QUERY_KEY });
+    },
+  });
+}
+
+// DELETE /api/admin/notices/:id
+export function useDeleteNotice() {
+  const queryClient = useQueryClient();
+  return useMutation<null, Error, number>({
+    mutationFn: id => fetchDeleteJsonOnAPI<null>(`/api/admin/notices/${id}`),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: NOTICES_QUERY_KEY });
+    },
+  });
+}

--- a/packages/admin/src/hooks/server/useAdminNotices.ts
+++ b/packages/admin/src/hooks/server/useAdminNotices.ts
@@ -1,4 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useToastNotification } from '@allcll/common';
 import { fetchJsonOnAPI, fetchDeleteJsonOnAPI } from '@/utils/api';
 import { OperationType, OPERATION_TYPE_LABEL, OPERATION_TYPES } from '@/hooks/server/useAdminReviews';
 
@@ -78,10 +79,14 @@ export function useUpdateNotice(id: number) {
 // DELETE /api/admin/notices/:id
 export function useDeleteNotice() {
   const queryClient = useQueryClient();
+  const toast = useToastNotification.getState().addToast;
   return useMutation<null, Error, number>({
     mutationFn: id => fetchDeleteJsonOnAPI<null>(`/api/admin/notices/${id}`),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: NOTICES_QUERY_KEY });
+    },
+    onError: () => {
+      toast('공지사항 삭제에 실패했습니다.');
     },
   });
 }

--- a/packages/admin/src/hooks/server/useAdminNotices.ts
+++ b/packages/admin/src/hooks/server/useAdminNotices.ts
@@ -1,45 +1,17 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { fetchJsonOnAPI, fetchDeleteJsonOnAPI } from '@/utils/api';
+import { OperationType, OPERATION_TYPE_LABEL, OPERATION_TYPES } from '@/hooks/server/useAdminReviews';
+
+export const CATEGORY_LABELS = OPERATION_TYPE_LABEL;
+export const NOTICE_CATEGORIES = OPERATION_TYPES;
 
 export interface Notice {
   id: number;
   title: string;
   content: string;
-  category: NoticeCategory;
+  operationType: OperationType;
   createdAt: string;
 }
-
-export type NoticeCategory =
-  | 'SERVICE'
-  | 'GRADUATION'
-  | 'TIMETABLE'
-  | 'REALTIME'
-  | 'COURSE_ANALYSIS'
-  | 'SIMULATION'
-  | 'WISHLIST';
-
-export type NoticeCategoryAll = NoticeCategory | 'ALL';
-
-export const CATEGORY_LABELS: Record<NoticeCategoryAll, string> = {
-  ALL: '전체',
-  SERVICE: '서비스',
-  GRADUATION: '졸업요건',
-  TIMETABLE: '시간표',
-  REALTIME: '실시간 여석',
-  COURSE_ANALYSIS: '과목분석',
-  SIMULATION: '수강신청 연습',
-  WISHLIST: '관심과목',
-};
-
-export const NOTICE_CATEGORIES: NoticeCategory[] = [
-  'SERVICE',
-  'GRADUATION',
-  'TIMETABLE',
-  'REALTIME',
-  'COURSE_ANALYSIS',
-  'SIMULATION',
-  'WISHLIST',
-];
 
 interface NoticesResponse {
   notices: Notice[];
@@ -69,7 +41,7 @@ export function useAdminNotice(id: number | undefined) {
 interface NoticePayload {
   title: string;
   content: string;
-  category: NoticeCategory;
+  operationType: OperationType;
 }
 
 // POST /api/admin/notices

--- a/packages/admin/src/hooks/server/useAdminNotices.ts
+++ b/packages/admin/src/hooks/server/useAdminNotices.ts
@@ -11,6 +11,7 @@ export interface Notice {
   content: string;
   operationType: OperationType;
   createdAt: string;
+  updatedAt: string;
 }
 
 interface NoticesResponse {

--- a/packages/admin/src/hooks/server/useAdminNotices.ts
+++ b/packages/admin/src/hooks/server/useAdminNotices.ts
@@ -46,30 +46,20 @@ interface NoticePayload {
   operationType: OperationType;
 }
 
-// POST /api/admin/notices
-export function useCreateNotice() {
+// POST 또는 PATCH /api/admin/notices[/:id]
+export function useSaveNotice(id?: number) {
   const queryClient = useQueryClient();
   return useMutation<Notice, Error, NoticePayload>({
     mutationFn: payload =>
-      fetchJsonOnAPI<Notice>('/api/admin/notices', {
-        method: 'POST',
-        body: JSON.stringify(payload),
-      }),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: NOTICES_QUERY_KEY });
-    },
-  });
-}
-
-// PATCH /api/admin/notices/:id
-export function useUpdateNotice(id: number) {
-  const queryClient = useQueryClient();
-  return useMutation<Notice, Error, NoticePayload>({
-    mutationFn: payload =>
-      fetchJsonOnAPI<Notice>(`/api/admin/notices/${id}`, {
-        method: 'PATCH',
-        body: JSON.stringify(payload),
-      }),
+      id !== undefined
+        ? fetchJsonOnAPI<Notice>(`/api/admin/notices/${id}`, {
+            method: 'PATCH',
+            body: JSON.stringify(payload),
+          })
+        : fetchJsonOnAPI<Notice>('/api/admin/notices', {
+            method: 'POST',
+            body: JSON.stringify(payload),
+          }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: NOTICES_QUERY_KEY });
     },

--- a/packages/admin/src/hooks/server/useAdminReviews.ts
+++ b/packages/admin/src/hooks/server/useAdminReviews.ts
@@ -1,12 +1,39 @@
 import { useQuery } from '@tanstack/react-query';
 import { fetchJsonOnAPI } from '@/utils/api.ts';
 
-export type OperationType = 'GRADUATION';
-export const MAX_RATE = 3;
+export type OperationType =
+  | 'ALL'
+  | 'TIMETABLE'
+  | 'BASKETS'
+  | 'SIMULATION'
+  | 'LIVE'
+  | 'PRESEAT'
+  | 'GRADUATION'
+  | 'REVIEW';
 
 export const OPERATION_TYPE_LABEL: Record<OperationType, string> = {
+  ALL: '전체',
+  TIMETABLE: '시간표',
+  BASKETS: '관심과목',
+  SIMULATION: '수강신청 연습',
+  LIVE: '실시간 여석',
+  PRESEAT: '사전좌석',
   GRADUATION: '졸업요건',
+  REVIEW: '후기',
 };
+
+export const OPERATION_TYPES: OperationType[] = [
+  'ALL',
+  'TIMETABLE',
+  'BASKETS',
+  'SIMULATION',
+  'LIVE',
+  'PRESEAT',
+  'GRADUATION',
+  'REVIEW',
+];
+
+export const MAX_RATE = 3;
 
 export interface Review {
   id: number;

--- a/packages/admin/src/hooks/server/useAdminReviews.ts
+++ b/packages/admin/src/hooks/server/useAdminReviews.ts
@@ -1,17 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { fetchJsonOnAPI } from '@/utils/api.ts';
 
-export type OperationType =
-  | 'ALL'
-  | 'TIMETABLE'
-  | 'BASKETS'
-  | 'SIMULATION'
-  | 'LIVE'
-  | 'PRESEAT'
-  | 'GRADUATION'
-  | 'REVIEW';
-
-export const OPERATION_TYPE_LABEL: Record<OperationType, string> = {
+export const OPERATION_TYPE_LABEL = {
   ALL: '전체',
   TIMETABLE: '시간표',
   BASKETS: '관심과목',
@@ -20,18 +10,10 @@ export const OPERATION_TYPE_LABEL: Record<OperationType, string> = {
   PRESEAT: '사전좌석',
   GRADUATION: '졸업요건',
   REVIEW: '후기',
-};
+} as const;
 
-export const OPERATION_TYPES: OperationType[] = [
-  'ALL',
-  'TIMETABLE',
-  'BASKETS',
-  'SIMULATION',
-  'LIVE',
-  'PRESEAT',
-  'GRADUATION',
-  'REVIEW',
-];
+export type OperationType = keyof typeof OPERATION_TYPE_LABEL;
+export const OPERATION_TYPES = Object.keys(OPERATION_TYPE_LABEL) as OperationType[];
 
 export const MAX_RATE = 3;
 

--- a/packages/admin/src/main.tsx
+++ b/packages/admin/src/main.tsx
@@ -21,9 +21,14 @@ const UsingMockServer = import.meta.env.VITE_USE_MOCK === 'true';
 if (UsingMockServer) {
   const { server } = await import('@allcll/mock-server');
 
-  server.start().then(() => {
-    loadApp();
-  });
+  server
+    .start({ onUnhandledRequest: 'bypass' })
+    .then(() => {
+      loadApp();
+    })
+    .catch(() => {
+      loadApp();
+    });
 } else {
   loadApp();
 }

--- a/packages/admin/src/main.tsx
+++ b/packages/admin/src/main.tsx
@@ -21,14 +21,9 @@ const UsingMockServer = import.meta.env.VITE_USE_MOCK === 'true';
 if (UsingMockServer) {
   const { server } = await import('@allcll/mock-server');
 
-  server
-    .start({ onUnhandledRequest: 'bypass' })
-    .then(() => {
-      loadApp();
-    })
-    .catch(() => {
-      loadApp();
-    });
+  server.start().then(() => {
+    loadApp();
+  });
 } else {
   loadApp();
 }

--- a/packages/admin/src/pages/NoticeEditor.tsx
+++ b/packages/admin/src/pages/NoticeEditor.tsx
@@ -1,0 +1,206 @@
+import { useState, useEffect, useCallback } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import ArrowLeftSvg from '@/assets/arrow-left.svg?react';
+import SaveSvg from '@/assets/save.svg?react';
+import { Card, Button, TextField, Label, Flex } from '@allcll/allcll-ui';
+import PageHeader from '@/components/common/PageHeader';
+import MarkdownEditor from '@/components/notices/MarkdownEditor';
+import UnsavedModal from '@/components/notices/UnsavedModal';
+import {
+  useAdminNotice,
+  useCreateNotice,
+  useUpdateNotice,
+  CATEGORY_LABELS,
+  NOTICE_CATEGORIES,
+  type NoticeCategory,
+} from '@/hooks/server/useAdminNotices';
+
+const MAX_LENGTH = 10000;
+
+function NoticeEditor() {
+  const navigate = useNavigate();
+  const { id } = useParams<{ id: string }>();
+  const isEditMode = id !== undefined;
+  const numericId = isEditMode ? Number(id) : undefined;
+
+  const { data: existingNotice, isLoading: isLoadingNotice } = useAdminNotice(numericId);
+  const { mutate: createNotice, isPending: isCreating } = useCreateNotice();
+  const { mutate: updateNotice, isPending: isUpdating } = useUpdateNotice(numericId ?? 0);
+
+  const isSaving = isCreating || isUpdating;
+
+  const [title, setTitle] = useState('');
+  const [category, setCategory] = useState<NoticeCategory>('GRADUATION');
+  const [content, setContent] = useState('');
+  const [isDirty, setIsDirty] = useState(false);
+  const [showUnsavedModal, setShowUnsavedModal] = useState(false);
+  const [errors, setErrors] = useState<string[]>([]);
+
+  useEffect(() => {
+    if (existingNotice) {
+      setTitle(existingNotice.title);
+      setCategory(existingNotice.category);
+      setContent(existingNotice.content);
+      setIsDirty(false);
+    }
+  }, [existingNotice]);
+
+  useEffect(() => {
+    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+      if (isDirty) e.preventDefault();
+    };
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    return () => window.removeEventListener('beforeunload', handleBeforeUnload);
+  }, [isDirty]);
+
+  const handleBack = () => {
+    if (isDirty) {
+      setShowUnsavedModal(true);
+    } else {
+      navigate('/notices');
+    }
+  };
+
+  const validate = () => {
+    const errs: string[] = [];
+    if (!title.trim()) errs.push('제목을 입력해주세요.');
+    if (!content.trim()) errs.push('내용을 입력해주세요.');
+    if (content.length > MAX_LENGTH) errs.push(`내용은 ${MAX_LENGTH.toLocaleString()}자를 초과할 수 없습니다.`);
+    setErrors(errs);
+    return errs.length === 0;
+  };
+
+  const handleSave = useCallback(() => {
+    if (!validate()) return;
+    const payload = { title: title.trim(), content, category };
+    if (isEditMode && numericId !== undefined) {
+      updateNotice(payload, {
+        onSuccess: () => {
+          setIsDirty(false);
+          navigate('/notices');
+        },
+      });
+    } else {
+      createNotice(payload, {
+        onSuccess: () => {
+          setIsDirty(false);
+          navigate('/notices');
+        },
+      });
+    }
+  }, [title, content, category, isEditMode, numericId]);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      const isMod = e.ctrlKey || e.metaKey;
+      if (isMod && e.key === 'Enter') {
+        e.preventDefault();
+        handleSave();
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [handleSave]);
+
+  const isOverLimit = content.length > MAX_LENGTH;
+
+  if (isEditMode && isLoadingNotice) {
+    return (
+      <Flex direction="flex-col" gap="gap-5" className="h-full">
+        <Flex align="items-center" justify="justify-center" className="flex-1 text-gray-400">
+          불러오는 중...
+        </Flex>
+      </Flex>
+    );
+  }
+
+  return (
+    <Flex direction="flex-col" gap="gap-5" className="h-full">
+      <Flex align="items-center" justify="justify-between">
+        <Flex align="items-center" gap="gap-2">
+          <button
+            type="button"
+            onClick={handleBack}
+            className="p-1 rounded-md text-gray-400 hover:text-gray-700 hover:bg-gray-100 transition-colors"
+          >
+            <ArrowLeftSvg className="w-5 h-5" />
+          </button>
+          <PageHeader title={isEditMode ? '공지사항 수정' : '새 공지 작성'} />
+        </Flex>
+        <Button variant="primary" size="small" onClick={handleSave} disabled={isSaving || isOverLimit}>
+          <SaveSvg className="w-4 h-4 mr-1" />
+          {isSaving ? '저장 중...' : '저장하기'}
+        </Button>
+      </Flex>
+
+      {errors.length > 0 && (
+        <div className="bg-red-50 border border-red-200 rounded-lg px-4 py-3">
+          {errors.map((e, i) => (
+            <p key={i} className="text-sm text-red-700">
+              {e}
+            </p>
+          ))}
+        </div>
+      )}
+
+      <Card className="flex flex-col gap-5 p-5">
+        <TextField
+          id="notice-title"
+          label="제목"
+          size="small"
+          value={title}
+          onChange={e => {
+            setTitle(e.target.value);
+            setIsDirty(true);
+          }}
+          placeholder="공지사항 제목 입력"
+          onClear={() => {
+            setTitle('');
+            setIsDirty(true);
+          }}
+        />
+
+        <Flex direction="flex-col" gap="gap-1.5">
+          <Label id="notice-category">카테고리</Label>
+          <select
+            id="notice-category"
+            value={category}
+            onChange={e => {
+              setCategory(e.target.value as NoticeCategory);
+              setIsDirty(true);
+            }}
+            className="w-48 p-2 rounded-md bg-white border border-gray-400 text-sm text-gray-900"
+          >
+            {NOTICE_CATEGORIES.map(cat => (
+              <option key={cat} value={cat}>
+                {CATEGORY_LABELS[cat]}
+              </option>
+            ))}
+          </select>
+        </Flex>
+
+        <MarkdownEditor
+          content={content}
+          onChange={v => {
+            setContent(v);
+            setIsDirty(true);
+          }}
+        />
+      </Card>
+      <div className="pb-6" />
+
+      {showUnsavedModal && (
+        <UnsavedModal
+          onCancel={() => setShowUnsavedModal(false)}
+          onConfirm={() => {
+            setIsDirty(false);
+            setShowUnsavedModal(false);
+            navigate('/notices');
+          }}
+        />
+      )}
+    </Flex>
+  );
+}
+
+export default NoticeEditor;

--- a/packages/admin/src/pages/NoticeEditor.tsx
+++ b/packages/admin/src/pages/NoticeEditor.tsx
@@ -12,10 +12,11 @@ import {
   useUpdateNotice,
   CATEGORY_LABELS,
   NOTICE_CATEGORIES,
-  type NoticeCategory,
 } from '@/hooks/server/useAdminNotices';
+import { type OperationType } from '@/hooks/server/useAdminReviews';
 
-const MAX_LENGTH = 10000;
+const MAX_LENGTH = 1000;
+const MAX_TITLE_LENGTH = 250;
 
 function NoticeEditor() {
   const navigate = useNavigate();
@@ -30,7 +31,7 @@ function NoticeEditor() {
   const isSaving = isCreating || isUpdating;
 
   const [title, setTitle] = useState('');
-  const [category, setCategory] = useState<NoticeCategory>('GRADUATION');
+  const [category, setCategory] = useState<OperationType>('GRADUATION');
   const [content, setContent] = useState('');
   const [isDirty, setIsDirty] = useState(false);
   const [showUnsavedModal, setShowUnsavedModal] = useState(false);
@@ -39,7 +40,7 @@ function NoticeEditor() {
   useEffect(() => {
     if (existingNotice) {
       setTitle(existingNotice.title);
-      setCategory(existingNotice.category);
+      setCategory(existingNotice.operationType);
       setContent(existingNotice.content);
       setIsDirty(false);
     }
@@ -64,6 +65,7 @@ function NoticeEditor() {
   const validate = () => {
     const errs: string[] = [];
     if (!title.trim()) errs.push('제목을 입력해주세요.');
+    if (title.length > MAX_TITLE_LENGTH) errs.push(`제목은 ${MAX_TITLE_LENGTH}자를 초과할 수 없습니다.`);
     if (!content.trim()) errs.push('내용을 입력해주세요.');
     if (content.length > MAX_LENGTH) errs.push(`내용은 ${MAX_LENGTH.toLocaleString()}자를 초과할 수 없습니다.`);
     setErrors(errs);
@@ -72,7 +74,7 @@ function NoticeEditor() {
 
   const handleSave = useCallback(() => {
     if (!validate()) return;
-    const payload = { title: title.trim(), content, category };
+    const payload = { title: title.trim(), content, operationType: category };
     if (isEditMode && numericId !== undefined) {
       updateNotice(payload, {
         onSuccess: () => {
@@ -102,7 +104,7 @@ function NoticeEditor() {
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, [handleSave]);
 
-  const isOverLimit = content.length > MAX_LENGTH;
+  const isOverLimit = content.length > MAX_LENGTH || title.length > MAX_TITLE_LENGTH;
 
   if (isEditMode && isLoadingNotice) {
     return (
@@ -144,21 +146,30 @@ function NoticeEditor() {
       )}
 
       <Card className="flex flex-col gap-5 p-5">
-        <TextField
-          id="notice-title"
-          label="제목"
-          size="small"
-          value={title}
-          onChange={e => {
-            setTitle(e.target.value);
-            setIsDirty(true);
-          }}
-          placeholder="공지사항 제목 입력"
-          onClear={() => {
-            setTitle('');
-            setIsDirty(true);
-          }}
-        />
+        <Flex direction="flex-col" gap="gap-1">
+          <TextField
+            id="notice-title"
+            label="제목"
+            size="small"
+            value={title}
+            onChange={e => {
+              setTitle(e.target.value);
+              setIsDirty(true);
+            }}
+            placeholder="공지사항 제목 입력"
+            onClear={() => {
+              setTitle('');
+              setIsDirty(true);
+            }}
+          />
+          <Flex justify="justify-end">
+            <span
+              className={`text-xs ${title.length > MAX_TITLE_LENGTH ? 'text-red-600 font-semibold' : 'text-gray-400'}`}
+            >
+              {title.length} / {MAX_TITLE_LENGTH}자
+            </span>
+          </Flex>
+        </Flex>
 
         <Flex direction="flex-col" gap="gap-1.5">
           <Label id="notice-category">카테고리</Label>
@@ -166,7 +177,7 @@ function NoticeEditor() {
             id="notice-category"
             value={category}
             onChange={e => {
-              setCategory(e.target.value as NoticeCategory);
+              setCategory(e.target.value as OperationType);
               setIsDirty(true);
             }}
             className="w-48 p-2 rounded-md bg-white border border-gray-400 text-sm text-gray-900"

--- a/packages/admin/src/pages/NoticeEditor.tsx
+++ b/packages/admin/src/pages/NoticeEditor.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import ArrowLeftSvg from '@/assets/arrow-left.svg?react';
 import SaveSvg from '@/assets/save.svg?react';
@@ -62,18 +62,15 @@ function NoticeEditor() {
     }
   };
 
-  const validate = () => {
+  const handleSave = () => {
+    if (isSaving) return;
     const errs: string[] = [];
     if (!title.trim()) errs.push('제목을 입력해주세요.');
     if (title.length > MAX_TITLE_LENGTH) errs.push(`제목은 ${MAX_TITLE_LENGTH}자를 초과할 수 없습니다.`);
     if (!content.trim()) errs.push('내용을 입력해주세요.');
     if (content.length > MAX_LENGTH) errs.push(`내용은 ${MAX_LENGTH.toLocaleString()}자를 초과할 수 없습니다.`);
     setErrors(errs);
-    return errs.length === 0;
-  };
-
-  const handleSave = useCallback(() => {
-    if (!validate()) return;
+    if (errs.length > 0) return;
     const payload = { title: title.trim(), content, operationType: category };
     if (isEditMode && numericId !== undefined) {
       updateNotice(payload, {
@@ -90,19 +87,22 @@ function NoticeEditor() {
         },
       });
     }
-  }, [title, content, category, isEditMode, numericId]);
+  };
+
+  const handleSaveRef = useRef(handleSave);
+  handleSaveRef.current = handleSave;
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       const isMod = e.ctrlKey || e.metaKey;
       if (isMod && e.key === 'Enter') {
         e.preventDefault();
-        handleSave();
+        handleSaveRef.current();
       }
     };
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [handleSave]);
+  }, []);
 
   const isOverLimit = content.length > MAX_LENGTH || title.length > MAX_TITLE_LENGTH;
 

--- a/packages/admin/src/pages/NoticeEditor.tsx
+++ b/packages/admin/src/pages/NoticeEditor.tsx
@@ -6,13 +6,7 @@ import { Card, Button, TextField, Label, Flex } from '@allcll/allcll-ui';
 import PageHeader from '@/components/common/PageHeader';
 import MarkdownEditor from '@/components/notices/MarkdownEditor';
 import UnsavedModal from '@/components/notices/UnsavedModal';
-import {
-  useAdminNotice,
-  useCreateNotice,
-  useUpdateNotice,
-  CATEGORY_LABELS,
-  NOTICE_CATEGORIES,
-} from '@/hooks/server/useAdminNotices';
+import { useAdminNotice, useSaveNotice, CATEGORY_LABELS, NOTICE_CATEGORIES } from '@/hooks/server/useAdminNotices';
 import { type OperationType } from '@/hooks/server/useAdminReviews';
 
 const MAX_LENGTH = 1000;
@@ -34,10 +28,7 @@ function NoticeEditor() {
   const numericId = isEditMode ? Number(id) : undefined;
 
   const { data: existingNotice, isLoading: isLoadingNotice } = useAdminNotice(numericId);
-  const { mutate: createNotice, isPending: isCreating } = useCreateNotice();
-  const { mutate: updateNotice, isPending: isUpdating } = useUpdateNotice(numericId ?? 0);
-
-  const isSaving = isCreating || isUpdating;
+  const { mutate: saveNotice, isPending: isSaving } = useSaveNotice(numericId);
 
   const [title, setTitle] = useState('');
   const [category, setCategory] = useState<OperationType>('GRADUATION');
@@ -77,21 +68,12 @@ function NoticeEditor() {
     setErrors(validationErrors);
     if (validationErrors.length > 0) return;
     const payload = { title: title.trim(), content, operationType: category };
-    if (isEditMode && numericId !== undefined) {
-      updateNotice(payload, {
-        onSuccess: () => {
-          setIsDirty(false);
-          navigate('/notices');
-        },
-      });
-    } else {
-      createNotice(payload, {
-        onSuccess: () => {
-          setIsDirty(false);
-          navigate('/notices');
-        },
-      });
-    }
+    saveNotice(payload, {
+      onSuccess: () => {
+        setIsDirty(false);
+        navigate('/notices');
+      },
+    });
   };
 
   const handleSaveRef = useRef(handleSave);

--- a/packages/admin/src/pages/NoticeEditor.tsx
+++ b/packages/admin/src/pages/NoticeEditor.tsx
@@ -18,6 +18,15 @@ import { type OperationType } from '@/hooks/server/useAdminReviews';
 const MAX_LENGTH = 1000;
 const MAX_TITLE_LENGTH = 250;
 
+function validateNotice(title: string, content: string): string[] {
+  const errors: string[] = [];
+  if (!title.trim()) errors.push('제목을 입력해주세요.');
+  if (title.length > MAX_TITLE_LENGTH) errors.push(`제목은 ${MAX_TITLE_LENGTH}자를 초과할 수 없습니다.`);
+  if (!content.trim()) errors.push('내용을 입력해주세요.');
+  if (content.length > MAX_LENGTH) errors.push(`내용은 ${MAX_LENGTH.toLocaleString()}자를 초과할 수 없습니다.`);
+  return errors;
+}
+
 function NoticeEditor() {
   const navigate = useNavigate();
   const { id } = useParams<{ id: string }>();
@@ -64,13 +73,9 @@ function NoticeEditor() {
 
   const handleSave = () => {
     if (isSaving) return;
-    const errs: string[] = [];
-    if (!title.trim()) errs.push('제목을 입력해주세요.');
-    if (title.length > MAX_TITLE_LENGTH) errs.push(`제목은 ${MAX_TITLE_LENGTH}자를 초과할 수 없습니다.`);
-    if (!content.trim()) errs.push('내용을 입력해주세요.');
-    if (content.length > MAX_LENGTH) errs.push(`내용은 ${MAX_LENGTH.toLocaleString()}자를 초과할 수 없습니다.`);
-    setErrors(errs);
-    if (errs.length > 0) return;
+    const validationErrors = validateNotice(title, content);
+    setErrors(validationErrors);
+    if (validationErrors.length > 0) return;
     const payload = { title: title.trim(), content, operationType: category };
     if (isEditMode && numericId !== undefined) {
       updateNotice(payload, {
@@ -95,7 +100,7 @@ function NoticeEditor() {
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       const isMod = e.ctrlKey || e.metaKey;
-      if (isMod && e.key === 'Enter') {
+      if (isMod && (e.key.toLowerCase() === 's' || e.key === 'Enter')) {
         e.preventDefault();
         handleSaveRef.current();
       }

--- a/packages/admin/src/pages/NoticeEditor.tsx
+++ b/packages/admin/src/pages/NoticeEditor.tsx
@@ -179,6 +179,7 @@ function NoticeEditor() {
 
         <MarkdownEditor
           content={content}
+          maxLength={MAX_LENGTH}
           onChange={v => {
             setContent(v);
             setIsDirty(true);

--- a/packages/admin/src/pages/NoticeEditor.tsx
+++ b/packages/admin/src/pages/NoticeEditor.tsx
@@ -7,7 +7,7 @@ import PageHeader from '@/components/common/PageHeader';
 import MarkdownEditor from '@/components/notices/MarkdownEditor';
 import UnsavedModal from '@/components/notices/UnsavedModal';
 import { useAdminNotice, useSaveNotice, CATEGORY_LABELS, NOTICE_CATEGORIES } from '@/hooks/server/useAdminNotices';
-import { type OperationType } from '@/hooks/server/useAdminReviews';
+import type { OperationType } from '@/hooks/server/useAdminReviews';
 
 const MAX_LENGTH = 1000;
 const MAX_TITLE_LENGTH = 250;

--- a/packages/admin/src/pages/Notices.tsx
+++ b/packages/admin/src/pages/Notices.tsx
@@ -1,0 +1,99 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import PlusSvg from '@/assets/plus.svg?react';
+import { Button, Flex } from '@allcll/allcll-ui';
+import { Filtering, CheckboxAdapter } from '@allcll/common';
+import MultiSelectFilterOption from '@/components/common/MultiSelectFilterOption';
+import PageHeader from '@/components/common/PageHeader';
+import NoticeTable from '@/components/notices/NoticeTable';
+import NoticeViewModal from '@/components/notices/NoticeViewModal';
+import NoticeDeleteModal from '@/components/notices/NoticeDeleteModal';
+import {
+  useAdminNotices,
+  useDeleteNotice,
+  CATEGORY_LABELS,
+  NOTICE_CATEGORIES,
+  type Notice,
+  type NoticeCategory,
+} from '@/hooks/server/useAdminNotices';
+
+const CATEGORY_OPTIONS = NOTICE_CATEGORIES.map(value => ({ label: CATEGORY_LABELS[value], value }));
+
+function Notices() {
+  const navigate = useNavigate();
+  const { data: notices = [], isLoading, isError } = useAdminNotices();
+  const { mutate: deleteNotice, isPending: isDeleting } = useDeleteNotice();
+
+  const [selectedCategories, setSelectedCategories] = useState<NoticeCategory[]>([]);
+  const [viewTarget, setViewTarget] = useState<Notice | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<Notice | null>(null);
+
+  const filtered =
+    selectedCategories.length === 0
+      ? notices
+      : notices.filter(n => selectedCategories.includes(n.category as NoticeCategory));
+
+  const handleDeleteConfirm = () => {
+    if (!deleteTarget) return;
+    deleteNotice(deleteTarget.id, {
+      onSuccess: () => setDeleteTarget(null),
+    });
+  };
+
+  return (
+    <Flex direction="flex-col" gap="gap-5" className="h-full">
+      <Flex align="items-center" justify="justify-between">
+        <PageHeader title="공지사항 관리" description="등록된 공지사항을 관리합니다." />
+        <Button variant="primary" size="small" onClick={() => navigate('/notices/new')}>
+          <PlusSvg className="w-4 h-4 mr-1" />새 공지 작성
+        </Button>
+      </Flex>
+
+      <Flex as="main" direction="flex-col" gap="gap-4" className="flex-1 min-h-0">
+        <Flex align="items-center" gap="gap-2">
+          <Filtering label="카테고리" selected={selectedCategories.length > 0}>
+            <MultiSelectFilterOption
+              labelPrefix="카테고리"
+              selectedValues={selectedCategories}
+              setFilter={setSelectedCategories}
+              options={CATEGORY_OPTIONS}
+              ItemComponent={CheckboxAdapter}
+            />
+          </Filtering>
+        </Flex>
+
+        <NoticeTable
+          notices={filtered}
+          isLoading={isLoading}
+          isError={isError}
+          onView={setViewTarget}
+          onEdit={notice => navigate(`/notices/edit/${notice.id}`)}
+          onDelete={setDeleteTarget}
+        />
+        <div className="pb-6" />
+      </Flex>
+
+      {viewTarget && (
+        <NoticeViewModal
+          notice={viewTarget}
+          onClose={() => setViewTarget(null)}
+          onEdit={() => {
+            setViewTarget(null);
+            navigate(`/notices/edit/${viewTarget.id}`);
+          }}
+        />
+      )}
+
+      {deleteTarget && (
+        <NoticeDeleteModal
+          notice={deleteTarget}
+          onCancel={() => setDeleteTarget(null)}
+          onConfirm={handleDeleteConfirm}
+          isDeleting={isDeleting}
+        />
+      )}
+    </Flex>
+  );
+}
+
+export default Notices;

--- a/packages/admin/src/pages/Notices.tsx
+++ b/packages/admin/src/pages/Notices.tsx
@@ -8,14 +8,9 @@ import PageHeader from '@/components/common/PageHeader';
 import NoticeTable from '@/components/notices/NoticeTable';
 import NoticeViewModal from '@/components/notices/NoticeViewModal';
 import NoticeDeleteModal from '@/components/notices/NoticeDeleteModal';
-import {
-  useAdminNotices,
-  useDeleteNotice,
-  CATEGORY_LABELS,
-  NOTICE_CATEGORIES,
-  type Notice,
-} from '@/hooks/server/useAdminNotices';
-import { type OperationType } from '@/hooks/server/useAdminReviews';
+import { useAdminNotices, useDeleteNotice, CATEGORY_LABELS, NOTICE_CATEGORIES } from '@/hooks/server/useAdminNotices';
+import type { Notice } from '@/hooks/server/useAdminNotices';
+import type { OperationType } from '@/hooks/server/useAdminReviews';
 
 const CATEGORY_OPTIONS = NOTICE_CATEGORIES.map(value => ({ label: CATEGORY_LABELS[value], value }));
 

--- a/packages/admin/src/pages/Notices.tsx
+++ b/packages/admin/src/pages/Notices.tsx
@@ -14,8 +14,8 @@ import {
   CATEGORY_LABELS,
   NOTICE_CATEGORIES,
   type Notice,
-  type NoticeCategory,
 } from '@/hooks/server/useAdminNotices';
+import { type OperationType } from '@/hooks/server/useAdminReviews';
 
 const CATEGORY_OPTIONS = NOTICE_CATEGORIES.map(value => ({ label: CATEGORY_LABELS[value], value }));
 
@@ -24,14 +24,12 @@ function Notices() {
   const { data: notices = [], isLoading, isError } = useAdminNotices();
   const { mutate: deleteNotice, isPending: isDeleting } = useDeleteNotice();
 
-  const [selectedCategories, setSelectedCategories] = useState<NoticeCategory[]>([]);
+  const [selectedCategories, setSelectedCategories] = useState<OperationType[]>([]);
   const [viewTarget, setViewTarget] = useState<Notice | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<Notice | null>(null);
 
   const filtered =
-    selectedCategories.length === 0
-      ? notices
-      : notices.filter(n => selectedCategories.includes(n.category as NoticeCategory));
+    selectedCategories.length === 0 ? notices : notices.filter(n => selectedCategories.includes(n.operationType));
 
   const handleDeleteConfirm = () => {
     if (!deleteTarget) return;

--- a/packages/admin/src/utils/routing.tsx
+++ b/packages/admin/src/utils/routing.tsx
@@ -6,72 +6,107 @@ import Service from '@/pages/Service';
 import Logs from '@/pages/Logs';
 import Graduation from '@/pages/Graduation';
 import Reviews from '@/pages/Reviews';
+import Notices from '@/pages/Notices';
+import NoticeEditor from '@/pages/NoticeEditor';
 
-const router = createBrowserRouter([
-  {
-    path: '/',
-    element: <MainLayout />,
-    children: [
-      {
-        path: '/',
-        element: <Dashboard />,
-      },
-    ],
-  },
-  {
-    path: '/clawlers',
-    element: <MainLayout />,
-    children: [
-      {
-        path: '/clawlers',
-        element: <Clawlers />,
-      },
-    ],
-  },
-  {
-    path: '/graduation',
-    element: <MainLayout />,
-    children: [
-      {
-        path: '/graduation',
-        element: <Graduation />,
-      },
-    ],
-  },
-  {
-    path: '/service',
-    element: <MainLayout />,
-    children: [
-      {
-        path: '/service',
-        element: <Service />,
-      },
-    ],
-  },
-  {
-    path: '/logs',
-    element: <MainLayout />,
-    children: [
-      {
-        path: '/logs',
-        element: <Logs />,
-      },
-    ],
-  },
-  {
-    path: '/reviews',
-    element: <MainLayout />,
-    children: [
-      {
-        path: '/reviews',
-        element: <Reviews />,
-      },
-    ],
-  },
-  {
-    path: '*',
-    element: <div>404 Not Found</div>,
-  },
-], { basename: import.meta.env.BASE_URL });
+const router = createBrowserRouter(
+  [
+    {
+      path: '/',
+      element: <MainLayout />,
+      children: [
+        {
+          path: '/',
+          element: <Dashboard />,
+        },
+      ],
+    },
+    {
+      path: '/clawlers',
+      element: <MainLayout />,
+      children: [
+        {
+          path: '/clawlers',
+          element: <Clawlers />,
+        },
+      ],
+    },
+    {
+      path: '/graduation',
+      element: <MainLayout />,
+      children: [
+        {
+          path: '/graduation',
+          element: <Graduation />,
+        },
+      ],
+    },
+    {
+      path: '/service',
+      element: <MainLayout />,
+      children: [
+        {
+          path: '/service',
+          element: <Service />,
+        },
+      ],
+    },
+    {
+      path: '/logs',
+      element: <MainLayout />,
+      children: [
+        {
+          path: '/logs',
+          element: <Logs />,
+        },
+      ],
+    },
+    {
+      path: '/reviews',
+      element: <MainLayout />,
+      children: [
+        {
+          path: '/reviews',
+          element: <Reviews />,
+        },
+      ],
+    },
+    {
+      path: '/notices',
+      element: <MainLayout />,
+      children: [
+        {
+          path: '/notices',
+          element: <Notices />,
+        },
+      ],
+    },
+    {
+      path: '/notices/new',
+      element: <MainLayout />,
+      children: [
+        {
+          path: '/notices/new',
+          element: <NoticeEditor />,
+        },
+      ],
+    },
+    {
+      path: '/notices/edit/:id',
+      element: <MainLayout />,
+      children: [
+        {
+          path: '/notices/edit/:id',
+          element: <NoticeEditor />,
+        },
+      ],
+    },
+    {
+      path: '*',
+      element: <div>404 Not Found</div>,
+    },
+  ],
+  { basename: import.meta.env.BASE_URL },
+);
 
 export default router;

--- a/packages/admin/src/utils/routing.tsx
+++ b/packages/admin/src/utils/routing.tsx
@@ -7,6 +7,8 @@ import Logs from '@/pages/Logs';
 import Graduation from '@/pages/Graduation';
 import Reviews from '@/pages/Reviews';
 import GraduationView from '@/pages/GraduationView';
+import Notices from '@/pages/Notices';
+import NoticeEditor from '@/pages/NoticeEditor';
 
 const router = createBrowserRouter(
   [
@@ -71,6 +73,36 @@ const router = createBrowserRouter(
         {
           path: '/reviews/graduation/:studentId',
           element: <GraduationView />,
+        },
+      ],
+    },
+    {
+      path: '/notices',
+      element: <MainLayout />,
+      children: [
+        {
+          path: '/notices',
+          element: <Notices />,
+        },
+      ],
+    },
+    {
+      path: '/notices/new',
+      element: <MainLayout />,
+      children: [
+        {
+          path: '/notices/new',
+          element: <NoticeEditor />,
+        },
+      ],
+    },
+    {
+      path: '/notices/edit/:id',
+      element: <MainLayout />,
+      children: [
+        {
+          path: '/notices/edit/:id',
+          element: <NoticeEditor />,
         },
       ],
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,6 +111,12 @@ importers:
       react-helmet:
         specifier: ^6.1.0
         version: 6.1.0(react@18.3.1)
+      react-markdown:
+        specifier: ^10.1.0
+        version: 10.1.0(@types/react@19.2.14)(react@18.3.1)
+      remark-gfm:
+        specifier: ^4.0.1
+        version: 4.0.1
     devDependencies:
       '@allcll/mock-server':
         specifier: workspace:^

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,6 +114,9 @@ importers:
       react-markdown:
         specifier: ^10.1.0
         version: 10.1.0(@types/react@19.2.14)(react@18.3.1)
+      remark-breaks:
+        specifier: ^4.0.0
+        version: 4.0.0
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1
@@ -3422,6 +3425,9 @@ packages:
   mdast-util-mdxjs-esm@2.0.1:
     resolution: {integrity: sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==}
 
+  mdast-util-newline-to-break@2.0.0:
+    resolution: {integrity: sha512-MbgeFca0hLYIEx/2zGsszCSEJJ1JSCdiY5xQxRcLDDGa8EPvlLPupJ4DSajbMPAnC0je8jfb9TiUATnxxrHUog==}
+
   mdast-util-phrasing@4.1.0:
     resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
 
@@ -3902,6 +3908,9 @@ packages:
   regjsparser@0.13.0:
     resolution: {integrity: sha512-NZQZdC5wOE/H3UT28fVGL+ikOZcEzfMGk/c3iN9UGxzWHMa1op7274oyiUVrAG4B2EuFhus8SvkaYnhvW92p9Q==}
     hasBin: true
+
+  remark-breaks@4.0.0:
+    resolution: {integrity: sha512-IjEjJOkH4FuJvHZVIW0QCDWxcG96kCq7An/KVH2NfJe6rKZU2AsHeB3OEjPNRxi4QC34Xdx7I2KGYn6IpT7gxQ==}
 
   remark-gfm@4.0.1:
     resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
@@ -7754,6 +7763,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  mdast-util-newline-to-break@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-find-and-replace: 3.0.2
+
   mdast-util-phrasing@4.1.0:
     dependencies:
       '@types/mdast': 4.0.4
@@ -8371,6 +8385,12 @@ snapshots:
   regjsparser@0.13.0:
     dependencies:
       jsesc: 3.1.0
+
+  remark-breaks@4.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-newline-to-break: 2.0.0
+      unified: 11.0.5
 
   remark-gfm@4.0.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,6 +120,9 @@ importers:
       react-markdown:
         specifier: ^10.1.0
         version: 10.1.0(@types/react@19.2.14)(react@18.3.1)
+      remark-breaks:
+        specifier: ^4.0.0
+        version: 4.0.0
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,6 +117,12 @@ importers:
       react-helmet:
         specifier: ^6.1.0
         version: 6.1.0(react@18.3.1)
+      react-markdown:
+        specifier: ^10.1.0
+        version: 10.1.0(@types/react@19.2.14)(react@18.3.1)
+      remark-gfm:
+        specifier: ^4.0.1
+        version: 4.0.1
     devDependencies:
       '@allcll/mock-server':
         specifier: workspace:^


### PR DESCRIPTION
## 작업 내용

- 어드민에서 공지사항을 관리할 수 있도록 작성 / 조회 / 수정 / 삭제 기능 구현
- 공지 본문 마크다운 작성 및 미리보기 지원, 줄바꿈·코드블록 스타일 정리
- 카테고리별 필터링과 제목 / 내용 입력 길이 제한 적용
- 백엔드 응답에 추가된 수정일(updatedAt)을 목록 / 상세에 노출

## 변경 사항 및 리뷰 포인트

- 공지 카테고리는 백엔드에서 사용하는 `OperationType`을 사용
- 수정일을 메인, 작성일은 보조로 노출 
- 단건 조회 API 부재로 상세는 목록 캐시에서 추출하는 방식 사용 
- 입력 길이 제한: 제목 250자 / 내용 1000자 
