### PR TITLE
fix: 관심과목 분석 상세 페이지 버그 수정

### DIFF
--- a/packages/client/src/entities/semester/model/useSemesterNameBySubjectId.ts
+++ b/packages/client/src/entities/semester/model/useSemesterNameBySubjectId.ts
@@ -1,3 +1,5 @@
+import { SEMESTERS } from '../api/semester';
+
 const semesters = [
   { code: 'SPRING_25', startId: 1, endId: 2422 },
   { code: 'SUMMER_25', startId: 2562, endId: 2647 },
@@ -9,5 +11,14 @@ const semesters = [
 export function useSemesterNameBySubjectId(subjectId: number) {
   const semester = semesters.find(sem => subjectId >= sem.startId && subjectId <= sem.endId);
 
-  return { semesterCode: semester ? semester.code : undefined };
+  const semesterData = SEMESTERS.find(s => s.semesterCode === semester?.code);
+
+  if (!semesterData) {
+    return {
+      semesterCode: undefined,
+      semesterValue: undefined,
+    };
+  }
+
+  return semesterData;
 }

--- a/packages/client/src/entities/semester/model/useSemesterNameBySubjectId.ts
+++ b/packages/client/src/entities/semester/model/useSemesterNameBySubjectId.ts
@@ -1,6 +1,7 @@
 import { SEMESTERS } from '../api/semester';
 
-const semesters = [
+// Todo: 다음 학기에 SPRING_26 주석 해제 할 것
+const SEMESTER_RANGES = [
   { code: 'SPRING_25', startId: 1, endId: 2422 },
   { code: 'SUMMER_25', startId: 2562, endId: 2647 },
   { code: 'FALL_25', startId: 2648, endId: 5144 },
@@ -9,7 +10,7 @@ const semesters = [
 ];
 
 export function useSemesterNameBySubjectId(subjectId: number) {
-  const semester = semesters.find(sem => subjectId >= sem.startId && subjectId <= sem.endId);
+  const semester = SEMESTER_RANGES.find(sem => subjectId >= sem.startId && subjectId <= sem.endId);
 
   const semesterData = SEMESTERS.find(s => s.semesterCode === semester?.code);
 

--- a/packages/client/src/entities/semester/model/useSemesterNameBySubjectId.ts
+++ b/packages/client/src/entities/semester/model/useSemesterNameBySubjectId.ts
@@ -1,0 +1,13 @@
+const semesters = [
+  { code: 'SPRING_25', startId: 1, endId: 2422 },
+  { code: 'SUMMER_25', startId: 2562, endId: 2647 },
+  { code: 'FALL_25', startId: 2648, endId: 5144 },
+  { code: 'WINTER_25', startId: 5185, endId: 5253 },
+  // { code: "SPRING_26", startId: 5254, endId: 7862 },
+];
+
+export function useSemesterNameBySubjectId(subjectId: number) {
+  const semester = semesters.find(sem => subjectId >= sem.startId && subjectId <= sem.endId);
+
+  return { semesterCode: semester ? semester.code : undefined };
+}

--- a/packages/client/src/entities/semester/model/useSemesterNameBySubjectId.ts
+++ b/packages/client/src/entities/semester/model/useSemesterNameBySubjectId.ts
@@ -1,12 +1,14 @@
 import { SEMESTERS } from '../api/semester';
 
-// Todo: 다음 학기에 SPRING_26 주석 해제 할 것
+// Fixme: 매 학기마다 설정하는 항목이므로 따로 분리하여 관리할 것
+// Todo: 다음 학기에 SUMMER_26 주석 해제 할 것 (/public/${code} 폴더가 생기면, 해당 subject 추가할 것)
 const SEMESTER_RANGES = [
   { code: 'SPRING_25', startId: 1, endId: 2422 },
   { code: 'SUMMER_25', startId: 2562, endId: 2647 },
   { code: 'FALL_25', startId: 2648, endId: 5144 },
   { code: 'WINTER_25', startId: 5185, endId: 5253 },
-  // { code: "SPRING_26", startId: 5254, endId: 7862 },
+  { code: 'SPRING_26', startId: 5254, endId: 8222 },
+  // { code: 'SUMMER_26', startId: 8223, endId: 8310 },
 ];
 
 export function useSemesterNameBySubjectId(subjectId: number) {

--- a/packages/client/src/entities/subjectAggregate/model/useDetailWishes.ts
+++ b/packages/client/src/entities/subjectAggregate/model/useDetailWishes.ts
@@ -1,8 +1,7 @@
-import { Wishes } from '@/shared/model/types.ts';
+import { Wishes, WishesInfo } from '@/shared/model/types.ts';
 import useWishes, { InitWishes } from '@/entities/wishes/model/useWishes.ts';
 import { IPreRealSeat } from '@/entities/seat/api/usePreRealSeats';
 import { useJoinPreSeats } from '@/entities/subjectAggregate/lib/joinSubjects.ts';
-import { WishesInfo } from '@/features/wish/model/useWishesInfo';
 
 interface DetailWishes {
   isPending: boolean;

--- a/packages/client/src/entities/subjectAggregate/model/useDetailWishes.ts
+++ b/packages/client/src/entities/subjectAggregate/model/useDetailWishes.ts
@@ -6,7 +6,6 @@ import { useJoinPreSeats } from '@/entities/subjectAggregate/lib/joinSubjects';
 interface DetailWishes {
   isPending: boolean;
   data?: WishesWithSeat;
-  isPastSemester?: boolean;
 }
 
 type WishesWithSeat = Wishes | (Wishes & IPreRealSeat);
@@ -22,7 +21,6 @@ function useDetailWishes(wishesInfo: IWishesInfo): DetailWishes {
   return {
     isPending: false,
     data: detail,
-    isPastSemester: !!wishesInfo.semesterCode,
   };
 }
 

--- a/packages/client/src/entities/subjectAggregate/model/useDetailWishes.ts
+++ b/packages/client/src/entities/subjectAggregate/model/useDetailWishes.ts
@@ -2,6 +2,7 @@ import { Wishes } from '@/shared/model/types.ts';
 import useWishes, { InitWishes } from '@/entities/wishes/model/useWishes.ts';
 import { IPreRealSeat } from '@/entities/seat/api/usePreRealSeats';
 import { useJoinPreSeats } from '@/entities/subjectAggregate/lib/joinSubjects.ts';
+import { WishesInfo } from '@/features/wish/model/useWishesInfo';
 
 interface DetailWishes {
   isPending: boolean;
@@ -11,18 +12,18 @@ interface DetailWishes {
 
 type WishesWithSeat = Wishes | (Wishes & IPreRealSeat);
 
-function useDetailWishes(subjectId: number, semesterCode?: string): DetailWishes {
-  const { data: wishes } = useWishes(semesterCode);
+function useDetailWishes(wishesInfo: WishesInfo): DetailWishes {
+  const { data: wishes } = useWishes(wishesInfo.semesterCode);
   const data = useJoinPreSeats(wishes, InitWishes);
 
   if (!data) return { isPending: true };
 
-  const detail = data?.find(basket => basket.subjectId === subjectId);
+  const detail = data?.find(basket => basket.subjectId === wishesInfo.subjectId);
 
   return {
     isPending: false,
     data: detail,
-    isLastSemesterWish: !!semesterCode,
+    isLastSemesterWish: !!wishesInfo.semesterCode,
   };
 }
 

--- a/packages/client/src/entities/subjectAggregate/model/useDetailWishes.ts
+++ b/packages/client/src/entities/subjectAggregate/model/useDetailWishes.ts
@@ -1,17 +1,17 @@
-import { Wishes, WishesInfo } from '@/shared/model/types.ts';
-import useWishes, { InitWishes } from '@/entities/wishes/model/useWishes.ts';
-import { IPreRealSeat } from '@/entities/seat/api/usePreRealSeats';
-import { useJoinPreSeats } from '@/entities/subjectAggregate/lib/joinSubjects.ts';
+import type { Wishes, IWishesInfo } from '@/shared/model/types';
+import useWishes, { InitWishes } from '@/entities/wishes/model/useWishes';
+import type { IPreRealSeat } from '@/entities/seat/api/usePreRealSeats';
+import { useJoinPreSeats } from '@/entities/subjectAggregate/lib/joinSubjects';
 
 interface DetailWishes {
   isPending: boolean;
   data?: WishesWithSeat;
-  isLastSemesterWish?: boolean;
+  isPastSemester?: boolean;
 }
 
 type WishesWithSeat = Wishes | (Wishes & IPreRealSeat);
 
-function useDetailWishes(wishesInfo: WishesInfo): DetailWishes {
+function useDetailWishes(wishesInfo: IWishesInfo): DetailWishes {
   const { data: wishes } = useWishes(wishesInfo.semesterCode);
   const data = useJoinPreSeats(wishes, InitWishes);
 
@@ -22,7 +22,7 @@ function useDetailWishes(wishesInfo: WishesInfo): DetailWishes {
   return {
     isPending: false,
     data: detail,
-    isLastSemesterWish: !!wishesInfo.semesterCode,
+    isPastSemester: !!wishesInfo.semesterCode,
   };
 }
 

--- a/packages/client/src/entities/subjectAggregate/model/useDetailWishes.ts
+++ b/packages/client/src/entities/subjectAggregate/model/useDetailWishes.ts
@@ -11,8 +11,8 @@ interface DetailWishes {
 
 type WishesWithSeat = Wishes | (Wishes & IPreRealSeat);
 
-function useDetailWishes(subjectId: number): DetailWishes {
-  const { data: wishes } = useWishes();
+function useDetailWishes(subjectId: number, semesterCode?: string): DetailWishes {
+  const { data: wishes } = useWishes(semesterCode);
   const data = useJoinPreSeats(wishes, InitWishes);
 
   if (!data) return { isPending: true };
@@ -22,7 +22,7 @@ function useDetailWishes(subjectId: number): DetailWishes {
   return {
     isPending: false,
     data: detail,
-    isLastSemesterWish: !detail,
+    isLastSemesterWish: !!semesterCode,
   };
 }
 

--- a/packages/client/src/entities/subjectAggregate/model/useRecommendWishes.ts
+++ b/packages/client/src/entities/subjectAggregate/model/useRecommendWishes.ts
@@ -1,4 +1,4 @@
-import { IWishesInfo } from '@/shared/model/types';
+import type { IWishesInfo } from '@/shared/model/types';
 import useWishes, { InitWishes } from '@/entities/wishes/model/useWishes.ts';
 import { useJoinPreSeats } from '@/entities/subjectAggregate/lib/joinSubjects.ts';
 import useDetailWishes from '@/entities/subjectAggregate/model/useDetailWishes.ts';

--- a/packages/client/src/entities/subjectAggregate/model/useRecommendWishes.ts
+++ b/packages/client/src/entities/subjectAggregate/model/useRecommendWishes.ts
@@ -1,23 +1,20 @@
+import { WishesInfo } from '@/features/wish/model/useWishesInfo';
 import useWishes, { InitWishes } from '@/entities/wishes/model/useWishes.ts';
 import { useJoinPreSeats } from '@/entities/subjectAggregate/lib/joinSubjects.ts';
 import useDetailWishes from '@/entities/subjectAggregate/model/useDetailWishes.ts';
-import { useSemesterNameBySubjectId } from '@/entities/semester/model/useSemesterNameBySubjectId.ts';
 
-// Todo: Subject 부분은 따로 분리하기
 /** subjectId 에 대한 추천 과목을 반환합니다. */
-function useRecommendWishes(subjectId: number) {
-  const { semesterCode } = useSemesterNameBySubjectId(subjectId);
-  console.log('useDetailWishes called with subjectId:', subjectId, 'semesterCode:', semesterCode);
-
-  const { data: wishes } = useWishes(semesterCode);
-  const { data: wish } = useDetailWishes(subjectId, semesterCode);
+function useRecommendWishes(wishesInfo: WishesInfo) {
+  const { data: wishes } = useWishes(wishesInfo.semesterCode);
   const data = useJoinPreSeats(wishes, InitWishes);
 
+  // fixme: subjectCode 를 구하기 위한 용도.
+  const { data: wish } = useDetailWishes(wishesInfo);
   const subjectCode = wish?.subjectCode ?? '';
 
   if (!data) return { isPending: true };
 
-  const detail = data.filter(basket => basket.subjectCode === subjectCode && basket.subjectId !== subjectId);
+  const detail = data.filter(basket => basket.subjectCode === subjectCode && basket.subjectId !== wishesInfo.subjectId);
 
   return {
     isPending: false,

--- a/packages/client/src/entities/subjectAggregate/model/useRecommendWishes.ts
+++ b/packages/client/src/entities/subjectAggregate/model/useRecommendWishes.ts
@@ -1,12 +1,16 @@
 import useWishes, { InitWishes } from '@/entities/wishes/model/useWishes.ts';
 import { useJoinPreSeats } from '@/entities/subjectAggregate/lib/joinSubjects.ts';
 import useDetailWishes from '@/entities/subjectAggregate/model/useDetailWishes.ts';
+import { useSemesterNameBySubjectId } from '@/entities/semester/model/useSemesterNameBySubjectId.ts';
 
 // Todo: Subject 부분은 따로 분리하기
 /** subjectId 에 대한 추천 과목을 반환합니다. */
 function useRecommendWishes(subjectId: number) {
-  const { data: wishes } = useWishes();
-  const { data: wish } = useDetailWishes(subjectId);
+  const { semesterCode } = useSemesterNameBySubjectId(subjectId);
+  console.log('useDetailWishes called with subjectId:', subjectId, 'semesterCode:', semesterCode);
+
+  const { data: wishes } = useWishes(semesterCode);
+  const { data: wish } = useDetailWishes(subjectId, semesterCode);
   const data = useJoinPreSeats(wishes, InitWishes);
 
   const subjectCode = wish?.subjectCode ?? '';

--- a/packages/client/src/entities/subjectAggregate/model/useRecommendWishes.ts
+++ b/packages/client/src/entities/subjectAggregate/model/useRecommendWishes.ts
@@ -1,10 +1,10 @@
-import { WishesInfo } from '@/shared/model/types';
+import { IWishesInfo } from '@/shared/model/types';
 import useWishes, { InitWishes } from '@/entities/wishes/model/useWishes.ts';
 import { useJoinPreSeats } from '@/entities/subjectAggregate/lib/joinSubjects.ts';
 import useDetailWishes from '@/entities/subjectAggregate/model/useDetailWishes.ts';
 
 /** subjectId 에 대한 추천 과목을 반환합니다. */
-function useRecommendWishes(wishesInfo: WishesInfo) {
+function useRecommendWishes(wishesInfo: IWishesInfo) {
   const { data: wishes } = useWishes(wishesInfo.semesterCode);
   const data = useJoinPreSeats(wishes, InitWishes);
 

--- a/packages/client/src/entities/subjectAggregate/model/useRecommendWishes.ts
+++ b/packages/client/src/entities/subjectAggregate/model/useRecommendWishes.ts
@@ -1,4 +1,4 @@
-import { WishesInfo } from '@/features/wish/model/useWishesInfo';
+import { WishesInfo } from '@/shared/model/types';
 import useWishes, { InitWishes } from '@/entities/wishes/model/useWishes.ts';
 import { useJoinPreSeats } from '@/entities/subjectAggregate/lib/joinSubjects.ts';
 import useDetailWishes from '@/entities/subjectAggregate/model/useDetailWishes.ts';

--- a/packages/client/src/entities/wishes/api/wishes.ts
+++ b/packages/client/src/entities/wishes/api/wishes.ts
@@ -1,6 +1,6 @@
 import { fetchJsonOnPublic, fetchOnAPI } from '@/shared/api/api.ts';
 import { WishRegister } from '@/shared/model/types.ts';
-import { BadRequestError } from '@/shared/lib/errors.ts';
+import { BadRequestError, NotFoundError } from '@/shared/lib/errors.ts';
 
 export interface WishesApiResponse {
   baskets: { subjectId: number; totalCount: number }[];
@@ -25,8 +25,13 @@ export const fetchDetailRegisters = async (subjectId: number): Promise<DetailReg
     const errorMessage = await response.text();
     const parsedError = jsonParse(errorMessage);
 
-    if (parsedError?.status === '400 BAD_REQUEST') {
-      throw new BadRequestError(parsedError.code);
+    console.log('status', response.status);
+    if (response.status === 400) {
+      throw new BadRequestError(parsedError.message ?? response.statusText);
+    }
+
+    if (response.status === 404) {
+      throw new NotFoundError(parsedError.message ?? response.statusText);
     }
 
     throw new Error(await response.text());

--- a/packages/client/src/entities/wishes/api/wishes.ts
+++ b/packages/client/src/entities/wishes/api/wishes.ts
@@ -1,7 +1,7 @@
 import { fetchJsonOnPublic, fetchOnAPI } from '@/shared/api/api.ts';
-import { ApiException, WishRegister } from '@/shared/model/types.ts';
-import { BadRequestError, NotFoundError } from '@/shared/lib/errors.ts';
-import { jsonParse } from '@/shared/lib/parser.ts';
+import { ApiException, WishRegister } from '@/shared/model/types';
+import { BadRequestError, NotFoundError } from '@/shared/lib/errors';
+import { jsonParse } from '@/shared/lib/parser';
 
 export interface WishesApiResponse {
   baskets: { subjectId: number; totalCount: number }[];

--- a/packages/client/src/entities/wishes/api/wishes.ts
+++ b/packages/client/src/entities/wishes/api/wishes.ts
@@ -33,7 +33,7 @@ export const fetchDetailRegisters = async (subjectId: number): Promise<DetailReg
       throw new NotFoundError(parsedError.message ?? response.statusText);
     }
 
-    throw new Error(await response.text());
+    throw new Error(errorMessage);
   }
 
   return response.json();

--- a/packages/client/src/entities/wishes/api/wishes.ts
+++ b/packages/client/src/entities/wishes/api/wishes.ts
@@ -25,7 +25,6 @@ export const fetchDetailRegisters = async (subjectId: number): Promise<DetailReg
     const errorMessage = await response.text();
     const parsedError = jsonParse(errorMessage);
 
-    console.log('status', response.status);
     if (response.status === 400) {
       throw new BadRequestError(parsedError.message ?? response.statusText);
     }

--- a/packages/client/src/entities/wishes/api/wishes.ts
+++ b/packages/client/src/entities/wishes/api/wishes.ts
@@ -1,6 +1,7 @@
 import { fetchJsonOnPublic, fetchOnAPI } from '@/shared/api/api.ts';
-import { WishRegister } from '@/shared/model/types.ts';
+import { ApiException, WishRegister } from '@/shared/model/types.ts';
 import { BadRequestError, NotFoundError } from '@/shared/lib/errors.ts';
+import { jsonParse } from '@/shared/lib/parser.ts';
 
 export interface WishesApiResponse {
   baskets: { subjectId: number; totalCount: number }[];
@@ -23,26 +24,19 @@ export const fetchDetailRegisters = async (subjectId: number): Promise<DetailReg
 
   if (!response.ok) {
     const errorMessage = await response.text();
-    const parsedError = jsonParse(errorMessage);
+    const parsedError = jsonParse<ApiException>(errorMessage);
+    const errorText = parsedError?.message ?? response.statusText;
 
     if (response.status === 400) {
-      throw new BadRequestError(parsedError.message ?? response.statusText);
+      throw new BadRequestError(errorText);
     }
 
     if (response.status === 404) {
-      throw new NotFoundError(parsedError.message ?? response.statusText);
+      throw new NotFoundError(errorText);
     }
 
     throw new Error(errorMessage);
   }
 
   return response.json();
-};
-
-const jsonParse = (data: string) => {
-  try {
-    return JSON.parse(data);
-  } catch {
-    return null;
-  }
 };

--- a/packages/client/src/entities/wishes/model/useDetailRegisters.ts
+++ b/packages/client/src/entities/wishes/model/useDetailRegisters.ts
@@ -1,11 +1,12 @@
 import { useQuery } from '@tanstack/react-query';
-import { BadRequestError } from '@/shared/lib/errors.ts';
+import { WishesInfo } from '@/features/wish/model/useWishesInfo';
 import { fetchDetailRegisters } from '@/entities/wishes/api/wishes.ts';
+import { BadRequestError, NotFoundError } from '@/shared/lib/errors.ts';
 
-function useDetailRegisters(id: number) {
+function useDetailRegisters(wishesInfo: WishesInfo) {
   return useQuery({
-    queryKey: ['detail-registers', id],
-    queryFn: () => fetchDetailRegisters(id),
+    queryKey: ['detail-registers', wishesInfo.subjectId],
+    queryFn: () => fetchDetailRegisters(wishesInfo.subjectId),
     staleTime: Infinity,
     retry: retryCondition,
   });
@@ -15,7 +16,7 @@ const retryCondition = (failureCount: number, error: Error) => {
   if (failureCount >= 3) return false;
 
   // error 따라서 재시도 여부 결정
-  return !(error instanceof BadRequestError);
+  return !(error instanceof BadRequestError || error instanceof NotFoundError);
 };
 
 export default useDetailRegisters;

--- a/packages/client/src/entities/wishes/model/useDetailRegisters.ts
+++ b/packages/client/src/entities/wishes/model/useDetailRegisters.ts
@@ -1,9 +1,9 @@
 import { useQuery } from '@tanstack/react-query';
-import { WishesInfo } from '@/shared/model/types';
+import { IWishesInfo } from '@/shared/model/types';
 import { fetchDetailRegisters } from '@/entities/wishes/api/wishes.ts';
 import { BadRequestError, NotFoundError } from '@/shared/lib/errors.ts';
 
-function useDetailRegisters(wishesInfo: WishesInfo) {
+function useDetailRegisters(wishesInfo: IWishesInfo) {
   return useQuery({
     queryKey: ['detail-registers', wishesInfo.subjectId],
     queryFn: () => fetchDetailRegisters(wishesInfo.subjectId),

--- a/packages/client/src/entities/wishes/model/useDetailRegisters.ts
+++ b/packages/client/src/entities/wishes/model/useDetailRegisters.ts
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import { WishesInfo } from '@/features/wish/model/useWishesInfo';
+import { WishesInfo } from '@/shared/model/types';
 import { fetchDetailRegisters } from '@/entities/wishes/api/wishes.ts';
 import { BadRequestError, NotFoundError } from '@/shared/lib/errors.ts';
 

--- a/packages/client/src/features/wish/model/useWishesInfo.ts
+++ b/packages/client/src/features/wish/model/useWishesInfo.ts
@@ -1,20 +1,20 @@
 import { useParams } from 'react-router-dom';
 import { useSemesterNameBySubjectId } from '@/entities/semester/model/useSemesterNameBySubjectId';
-import { WishesInfo } from '@/shared/model/types';
+import type { IWishesInfo } from '@/shared/model/types';
 
 // 관심과목 상세 페이지에서 subjectId와 semesterCode를 가져오는 커스텀 훅
 // 다른 훅을 사용할 때, 정보를 주입
-function useWishesInfo(): WishesInfo {
+function useWishesInfo(): IWishesInfo {
   const params = useParams();
   const subjectId = Number(params.id ?? '-1');
 
   const semester = useSemesterNameBySubjectId(subjectId);
-  const isLastSemesterWish = Boolean(semester.semesterCode); // undefined이면 현재 학기 관심과목
+  const isPastSemester = Boolean(semester.semesterCode); // undefined이면 현재 학기 관심과목
 
   return {
     subjectId,
     ...semester,
-    isLastSemesterWish,
+    isPastSemester,
   };
 }
 

--- a/packages/client/src/features/wish/model/useWishesInfo.ts
+++ b/packages/client/src/features/wish/model/useWishesInfo.ts
@@ -1,12 +1,6 @@
 import { useParams } from 'react-router-dom';
 import { useSemesterNameBySubjectId } from '@/entities/semester/model/useSemesterNameBySubjectId';
-
-export interface WishesInfo {
-  subjectId: number;
-  semesterCode: string | undefined;
-  semesterValue: string | undefined;
-  isLastSemesterWish: boolean;
-}
+import { WishesInfo } from '@/shared/model/types';
 
 // 관심과목 상세 페이지에서 subjectId와 semesterCode를 가져오는 커스텀 훅
 // 다른 훅을 사용할 때, 정보를 주입

--- a/packages/client/src/features/wish/model/useWishesInfo.ts
+++ b/packages/client/src/features/wish/model/useWishesInfo.ts
@@ -1,0 +1,27 @@
+import { useParams } from 'react-router-dom';
+import { useSemesterNameBySubjectId } from '@/entities/semester/model/useSemesterNameBySubjectId';
+
+export interface WishesInfo {
+  subjectId: number;
+  semesterCode: string | undefined;
+  semesterValue: string | undefined;
+  isLastSemesterWish: boolean;
+}
+
+// 관심과목 상세 페이지에서 subjectId와 semesterCode를 가져오는 커스텀 훅
+// 다른 훅을 사용할 때, 정보를 주입
+function useWishesInfo(): WishesInfo {
+  const params = useParams();
+  const subjectId = Number(params.id ?? '-1');
+
+  const semester = useSemesterNameBySubjectId(subjectId);
+  const isLastSemesterWish = Boolean(semester.semesterCode); // undefined이면 현재 학기 관심과목
+
+  return {
+    subjectId,
+    ...semester,
+    isLastSemesterWish,
+  };
+}
+
+export default useWishesInfo;

--- a/packages/client/src/pages/wishlist/WishesDetail.tsx
+++ b/packages/client/src/pages/wishlist/WishesDetail.tsx
@@ -1,13 +1,12 @@
-import { useState } from 'react';
 import { Helmet } from 'react-helmet';
 import WishesBarChart from '@/widgets/wishlist/WishesBarChart.tsx';
 import DepartmentDoughnut from '@/widgets/wishlist/DepartmentDoughnut';
 import RecommendWishes from '@/widgets/wishlist/RecommendWishes';
 import WishesDetailInfo from '@/widgets/wishlist/WishesDetailInfo';
+import WishesSemesterBanner from '@/widgets/wishlist/WishesSemesterBanner';
 import useWishesInfo from '@/features/wish/model/useWishesInfo';
 import useDetailRegisters from '@/entities/wishes/model/useDetailRegisters';
-import { WishesInfo } from '@/shared/model/types';
-import { Banner, Card, Grid } from '@allcll/allcll-ui';
+import { Card, Grid } from '@allcll/allcll-ui';
 
 function WishesDetail() {
   const wishesInfo = useWishesInfo();
@@ -24,41 +23,26 @@ function WishesDetail() {
 
       <WishesSemesterBanner wishesInfo={wishesInfo} />
 
-      {/*Fixme: div depth 최적화하기*/}
-      <div className="min-h-screen bg-gray-50">
-        <div className="p-6 max-w-5xl mx-auto">
-          <Card>
-            <WishesDetailInfo wishesInfo={wishesInfo} />
+      <div className="min-h-screen bg-gray-50 p-6">
+        <Card className="max-w-5xl mx-auto">
+          <WishesDetailInfo wishesInfo={wishesInfo} />
 
-            {/* Analytics Section */}
-            <Grid columns={{ md: 2, base: 1 }} gap="gap-6" className=" mt-6">
-              <Card className="p-6">
-                <DepartmentDoughnut wishesInfo={wishesInfo} />
-              </Card>
-              <Card>
-                <WishesBarChart wishesInfo={wishesInfo} />
-              </Card>
-            </Grid>
-
-            <Card>
-              <RecommendWishes wishesInfo={wishesInfo} />
+          {/* Analytics Section */}
+          <Grid columns={{ md: 2, base: 1 }} gap="gap-6" className="mt-6">
+            <Card className="p-6">
+              <DepartmentDoughnut wishesInfo={wishesInfo} />
             </Card>
+            <Card className="p-6">
+              <WishesBarChart wishesInfo={wishesInfo} />
+            </Card>
+          </Grid>
+
+          <Card>
+            <RecommendWishes wishesInfo={wishesInfo} />
           </Card>
-        </div>
+        </Card>
       </div>
     </>
-  );
-}
-
-function WishesSemesterBanner({ wishesInfo }: { wishesInfo: WishesInfo }) {
-  const [showBanner, setShowBanner] = useState(true);
-
-  if (!wishesInfo.isLastSemesterWish || !showBanner) return null;
-
-  return (
-    <Banner variant="warning" deleteBanner={() => setShowBanner(false)}>
-      {wishesInfo.semesterValue}학기의 과목 입니다. 수강 신청에 유의해주세요.
-    </Banner>
   );
 }
 

--- a/packages/client/src/pages/wishlist/WishesDetail.tsx
+++ b/packages/client/src/pages/wishlist/WishesDetail.tsx
@@ -1,5 +1,5 @@
 import { Helmet } from 'react-helmet';
-import WishesBarChart from '@/widgets/wishlist/WishesBarChart.tsx';
+import WishesBarChart from '@/widgets/wishlist/WishesBarChart';
 import DepartmentDoughnut from '@/widgets/wishlist/DepartmentDoughnut';
 import RecommendWishes from '@/widgets/wishlist/RecommendWishes';
 import WishesDetailInfo from '@/widgets/wishlist/WishesDetailInfo';
@@ -37,7 +37,7 @@ function WishesDetail() {
             </Card>
           </Grid>
 
-          <Card>
+          <Card className="mt-2">
             <RecommendWishes wishesInfo={wishesInfo} />
           </Card>
         </Card>

--- a/packages/client/src/pages/wishlist/WishesDetail.tsx
+++ b/packages/client/src/pages/wishlist/WishesDetail.tsx
@@ -1,56 +1,28 @@
 import { Helmet } from 'react-helmet';
-import { useParams } from 'react-router-dom';
-import Table from '@/widgets/wishlist/Table';
+import useWishesInfo from '@/features/wish/model/useWishesInfo';
 import WishesBarChart from '@/widgets/wishlist/WishesBarChart.tsx';
-import DepartmentDoughnut from '@/widgets/wishlist/DepartmentDoughnut.tsx';
-import FavoriteButton from '@/features/filtering/ui/button/FavoriteButton.tsx';
-import AlarmButton from '@/features/live/pin/ui/AlarmButton';
-import { InitWishes } from '@/entities/wishes/model/useWishes.ts';
-import SubjectDetail from '@/entities/subjects/ui/SubjectDetail.tsx';
-import useDetailWishes from '@/entities/subjectAggregate/model/useDetailWishes.ts';
-import useRecommendWishes from '@/entities/subjectAggregate/model/useRecommendWishes.ts';
-import useDetailRegisters from '@/entities/wishes/model/useDetailRegisters.ts';
-import { useSemesterNameBySubjectId } from '@/entities/semester/model/useSemesterNameBySubjectId';
-import { getWishesColor } from '@/shared/config/colors.ts';
-import { Card, Flex, Grid, Heading, SupportingText } from '@allcll/allcll-ui';
+import DepartmentDoughnut from '@/widgets/wishlist/DepartmentDoughnut';
+import RecommendWishes from '@/widgets/wishlist/RecommendWishes';
+import WishesDetailInfo from '@/widgets/wishlist/WishesDetailInfo';
+import useDetailRegisters from '@/entities/wishes/model/useDetailRegisters';
+import { Card, Grid } from '@allcll/allcll-ui';
 
 function WishesDetail() {
-  const params = useParams();
-  const subjectId = Number(params.id ?? '-1');
+  const wishesInfo = useWishesInfo();
 
-  const { semesterCode } = useSemesterNameBySubjectId(subjectId);
-  const { data: wishes, isPending, isLastSemesterWish } = useDetailWishes(subjectId, semesterCode);
-  const { data: registers, error } = useDetailRegisters(subjectId);
-
-  const data = wishes ?? InitWishes;
-  const isWishesAvailable = wishes && 'totalCount' in wishes;
-
-  if (isPending || !data) {
-    return (
-      <>
-        <Helmet>
-          <title>ALLCLL | 관심과목 분석 상세</title>
-          <meta name="description" content="세종대학교 관심과목의 상세 정보를 확인해보세요." />
-        </Helmet>
-
-        <div className="min-h-screen bg-gray-50 flex justify-center items-center">
-          <h1 className="text-2xl font-bold">Loading...</h1>
-        </div>
-      </>
-    );
-  }
-
+  const { error } = useDetailRegisters(wishesInfo);
   if (error) throw error;
 
   return (
     <>
       <Helmet>
         <title>ALLCLL | 관심과목 분석 상세</title>
+        <meta name="description" content="세종대학교 관심과목의 상세 정보를 확인해보세요." />
       </Helmet>
 
-      {isLastSemesterWish && (
+      {wishesInfo.isLastSemesterWish && (
         <p className="bg-red-100 text-red-500 py-2 px-4 font-bold">
-          이번 학기의 과목이 아닙니다. 수강 신청에 유의해주세요.
+          {wishesInfo.semesterValue}학기의 과목 입니다. 수강 신청에 유의해주세요.
         </p>
       )}
 
@@ -58,70 +30,26 @@ function WishesDetail() {
       <div className="min-h-screen bg-gray-50">
         <div className="p-6 max-w-5xl mx-auto">
           <Card>
-            <Flex justify="justify-between" align="items-center">
-              <Heading level={1}>{data.subjectName}</Heading>
-
-              <Flex gap="gap-2">
-                <FavoriteButton subject={data} />
-                <AlarmButton subject={data} />
-              </Flex>
-            </Flex>
-            <SubjectDetail wishes={wishes} />
+            <WishesDetailInfo wishesInfo={wishesInfo} />
 
             {/* Analytics Section */}
             <Grid columns={{ md: 2, base: 1 }} gap="gap-6" className=" mt-6">
-              {/* Doughnut Chart */}
               <Card className="p-6">
-                <DepartmentDoughnut
-                  data={registers?.eachDepartmentRegisters ?? []}
-                  majorName={data.departmentName ?? data.manageDeptNm}
-                />
+                <DepartmentDoughnut wishesInfo={wishesInfo} />
               </Card>
-
-              {/* Competition Analysis */}
               <Card>
-                <Flex gap="gap-2" align="items-center" className="mb-4">
-                  <Heading level={2}>관심과목 경쟁률 예상</Heading>
-                  {isWishesAvailable && (
-                    <p className={`${getWishesColor(data.totalCount ?? -1)} font-bold text-xl`}>
-                      총 {data.totalCount}명
-                    </p>
-                  )}
-                </Flex>
-
-                <WishesBarChart />
+                <WishesBarChart wishesInfo={wishesInfo} />
               </Card>
             </Grid>
 
-            {/* Alternative Course Table */}
             <Card>
-              <Heading level={2} className="mt-2">
-                대체과목 추천
-              </Heading>
-              <SupportingText>학수번호가 같은 과목을 알려드려요</SupportingText>
-
-              <div className="overflow-x-auto">
-                <RecommendationTable subjectId={subjectId} />
-              </div>
+              <RecommendWishes wishesInfo={wishesInfo} />
             </Card>
           </Card>
         </div>
       </div>
     </>
   );
-}
-
-// Todo: 대체 과목 테이블, WishesTable 컴포넌트 합칠 수 있는지 확인
-// 대체과목 테이블 컴포넌트
-interface IRecommendationTableProps {
-  subjectId: number;
-}
-
-function RecommendationTable({ subjectId }: IRecommendationTableProps) {
-  const { data: recommend } = useRecommendWishes(subjectId);
-  const placeholder = { title: '추천할 대체 과목이 없습니다.' };
-
-  return <Table data={recommend ?? []} placeholder={placeholder} />;
 }
 
 export default WishesDetail;

--- a/packages/client/src/pages/wishlist/WishesDetail.tsx
+++ b/packages/client/src/pages/wishlist/WishesDetail.tsx
@@ -1,11 +1,13 @@
+import { useState } from 'react';
 import { Helmet } from 'react-helmet';
-import useWishesInfo from '@/features/wish/model/useWishesInfo';
 import WishesBarChart from '@/widgets/wishlist/WishesBarChart.tsx';
 import DepartmentDoughnut from '@/widgets/wishlist/DepartmentDoughnut';
 import RecommendWishes from '@/widgets/wishlist/RecommendWishes';
 import WishesDetailInfo from '@/widgets/wishlist/WishesDetailInfo';
+import useWishesInfo from '@/features/wish/model/useWishesInfo';
 import useDetailRegisters from '@/entities/wishes/model/useDetailRegisters';
-import { Card, Grid } from '@allcll/allcll-ui';
+import { WishesInfo } from '@/shared/model/types';
+import { Banner, Card, Grid } from '@allcll/allcll-ui';
 
 function WishesDetail() {
   const wishesInfo = useWishesInfo();
@@ -20,11 +22,7 @@ function WishesDetail() {
         <meta name="description" content="세종대학교 관심과목의 상세 정보를 확인해보세요." />
       </Helmet>
 
-      {wishesInfo.isLastSemesterWish && (
-        <p className="bg-red-100 text-red-500 py-2 px-4 font-bold">
-          {wishesInfo.semesterValue}학기의 과목 입니다. 수강 신청에 유의해주세요.
-        </p>
-      )}
+      <WishesSemesterBanner wishesInfo={wishesInfo} />
 
       {/*Fixme: div depth 최적화하기*/}
       <div className="min-h-screen bg-gray-50">
@@ -49,6 +47,18 @@ function WishesDetail() {
         </div>
       </div>
     </>
+  );
+}
+
+function WishesSemesterBanner({ wishesInfo }: { wishesInfo: WishesInfo }) {
+  const [showBanner, setShowBanner] = useState(true);
+
+  if (!wishesInfo.isLastSemesterWish || !showBanner) return null;
+
+  return (
+    <Banner variant="warning" deleteBanner={() => setShowBanner(false)}>
+      {wishesInfo.semesterValue}학기의 과목 입니다. 수강 신청에 유의해주세요.
+    </Banner>
   );
 }
 

--- a/packages/client/src/pages/wishlist/WishesDetail.tsx
+++ b/packages/client/src/pages/wishlist/WishesDetail.tsx
@@ -10,13 +10,16 @@ import SubjectDetail from '@/entities/subjects/ui/SubjectDetail.tsx';
 import useDetailWishes from '@/entities/subjectAggregate/model/useDetailWishes.ts';
 import useRecommendWishes from '@/entities/subjectAggregate/model/useRecommendWishes.ts';
 import useDetailRegisters from '@/entities/wishes/model/useDetailRegisters.ts';
+import { useSemesterNameBySubjectId } from '@/entities/semester/model/useSemesterNameBySubjectId';
 import { getWishesColor } from '@/shared/config/colors.ts';
 import { Card, Flex, Grid, Heading, SupportingText } from '@allcll/allcll-ui';
 
 function WishesDetail() {
   const params = useParams();
   const subjectId = Number(params.id ?? '-1');
-  const { data: wishes, isPending, isLastSemesterWish } = useDetailWishes(subjectId);
+
+  const { semesterCode } = useSemesterNameBySubjectId(subjectId);
+  const { data: wishes, isPending, isLastSemesterWish } = useDetailWishes(subjectId, semesterCode);
   const { data: registers, error } = useDetailRegisters(subjectId);
 
   const data = wishes ?? InitWishes;

--- a/packages/client/src/shared/lib/parser.ts
+++ b/packages/client/src/shared/lib/parser.ts
@@ -1,0 +1,15 @@
+/**
+ * JSON 문자열을 안전하게 파싱하여 지정한 타입으로 반환합니다.
+ * 파싱 중 에러가 발생하면 콘솔에 에러를 기록하고 null 을 반환합니다.
+ *
+ * @template T - 파싱 결과물에 기대하는 데이터 타입
+ * @param data - 파싱할 JSON 형식의 문자열
+ * @returns 파싱에 성공하면 `T` 타입의 객체를, 실패하면 null 을 반환합니다. */
+export const jsonParse = <T>(data: string): T | null => {
+  try {
+    return JSON.parse(data) as T;
+  } catch (error) {
+    console.error('Failed to parse JSON:', error);
+    return null;
+  }
+};

--- a/packages/client/src/shared/model/types.ts
+++ b/packages/client/src/shared/model/types.ts
@@ -79,3 +79,9 @@ export interface IWishesInfo {
  * progress: 과목 신청 프로세스
  * finish: 결과 모달 */
 export type SimulationStatusType = 'before' | 'start' | 'progress' | 'finish';
+
+/** API 대한 에러 타입 */
+export interface ApiException {
+  code: string;
+  message: string;
+}

--- a/packages/client/src/shared/model/types.ts
+++ b/packages/client/src/shared/model/types.ts
@@ -67,11 +67,11 @@ export interface Subject {
   // departmentName: string;
 }
 
-export interface WishesInfo {
+export interface IWishesInfo {
   subjectId: number;
   semesterCode: string | undefined;
   semesterValue: string | undefined;
-  isLastSemesterWish: boolean;
+  isPastSemester: boolean;
 }
 
 /** before: 튜토리얼 + 관심과목 선택

--- a/packages/client/src/shared/model/types.ts
+++ b/packages/client/src/shared/model/types.ts
@@ -67,6 +67,13 @@ export interface Subject {
   // departmentName: string;
 }
 
+export interface WishesInfo {
+  subjectId: number;
+  semesterCode: string | undefined;
+  semesterValue: string | undefined;
+  isLastSemesterWish: boolean;
+}
+
 /** before: 튜토리얼 + 관심과목 선택
  * start: 시작 -> 대기 -> 과목 불러오기 전
  * progress: 과목 신청 프로세스

--- a/packages/client/src/widgets/wishlist/DepartmentDoughnut.tsx
+++ b/packages/client/src/widgets/wishlist/DepartmentDoughnut.tsx
@@ -1,7 +1,6 @@
 import { useState } from 'react';
 import { Doughnut } from 'react-chartjs-2';
 import { Chart as ChartJS, ArcElement, Tooltip, Legend, BarElement, CategoryScale, LinearScale } from 'chart.js/auto';
-import useDepartments, { DepartmentDict, useDepartmentDict } from '@/entities/departments/api/useDepartments.ts';
 import {
   getCollegeDoughnutData,
   getDoughnutData,
@@ -9,10 +8,20 @@ import {
   getMajorDoughnutData,
   getUniversityDoughnutData,
 } from '@/features/wish/lib/doughnut';
+import { WishesInfo } from '@/features/wish/model/useWishesInfo';
+import useDepartments, { DepartmentDict, useDepartmentDict } from '@/entities/departments/api/useDepartments.ts';
+import useDetailWishes from '@/entities/subjectAggregate/model/useDetailWishes';
+import useDetailRegisters from '@/entities/wishes/model/useDetailRegisters';
+import { InitWishes } from '@/entities/wishes/model/useWishes';
+import LoadingWithMessage from '@/shared/ui/Loading';
 import { WishRegister } from '@/shared/model/types.ts';
 import { Flex, Heading, Label } from '@allcll/allcll-ui';
 
 ChartJS.register(ArcElement, Tooltip, Legend, BarElement, CategoryScale, LinearScale);
+
+interface DepartmentDoughnutProps {
+  wishesInfo: WishesInfo;
+}
 
 export enum DoughnutSelectType {
   MAJOR = '전공/비전공',
@@ -21,7 +30,14 @@ export enum DoughnutSelectType {
   COLLEGE = '학부',
 }
 
-function DepartmentDoughnut({ data, majorName }: Readonly<{ data?: WishRegister[]; majorName: string }>) {
+function DepartmentDoughnut({ wishesInfo }: DepartmentDoughnutProps) {
+  const { data: wishes, isPending } = useDetailWishes(wishesInfo);
+  const { data: registers } = useDetailRegisters(wishesInfo);
+
+  const data = registers?.eachDepartmentRegisters ?? [];
+  const nonNullWishes = wishes ?? InitWishes;
+  const majorName = nonNullWishes.departmentName ?? nonNullWishes.manageDeptNm;
+
   const [selectedFilter, setSelectedFilter] = useState<DoughnutSelectType>(DoughnutSelectType.MAJOR);
   const { data: departmentData } = useDepartments();
   const departmentDict = useDepartmentDict(departmentData);
@@ -48,7 +64,11 @@ function DepartmentDoughnut({ data, majorName }: Readonly<{ data?: WishRegister[
         </select>
       </Flex>
 
-      {!totalCount ? (
+      {isPending ? (
+        <Flex justify="justify-center" align="items-center" className="h-48">
+          <LoadingWithMessage message="관심과목 현황을 불러오는 중입니다..." />
+        </Flex>
+      ) : !totalCount ? (
         <Flex justify="justify-center" align="items-center" className="h-48">
           <p className="text-center text-gray-500 font-semibold">관심과목을 담은 사람이 없습니다.</p>
         </Flex>

--- a/packages/client/src/widgets/wishlist/DepartmentDoughnut.tsx
+++ b/packages/client/src/widgets/wishlist/DepartmentDoughnut.tsx
@@ -22,12 +22,14 @@ interface IDepartmentDoughnutProps {
   wishesInfo: IWishesInfo;
 }
 
-export enum DoughnutSelectType {
-  MAJOR = '전공/비전공',
-  UNIVERSITY = '대학',
-  DEPARTMENT = '학과',
-  COLLEGE = '학부',
-}
+const DOUGHNUT_SELECT_TYPES = {
+  MAJOR: '전공/비전공',
+  UNIVERSITY: '대학',
+  DEPARTMENT: '학과',
+  COLLEGE: '학부',
+} as const;
+
+type DoughnutSelectType = (typeof DOUGHNUT_SELECT_TYPES)[keyof typeof DOUGHNUT_SELECT_TYPES];
 
 function DepartmentDoughnut({ wishesInfo }: IDepartmentDoughnutProps) {
   const { data: wishes, isPending } = useDetailWishes(wishesInfo);
@@ -37,7 +39,7 @@ function DepartmentDoughnut({ wishesInfo }: IDepartmentDoughnutProps) {
   const nonNullWishes = wishes ?? InitWishes;
   const majorName = nonNullWishes.departmentName ?? nonNullWishes.manageDeptNm;
 
-  const [selectedFilter, setSelectedFilter] = useState<DoughnutSelectType>(DoughnutSelectType.MAJOR);
+  const [selectedFilter, setSelectedFilter] = useState<DoughnutSelectType>(DOUGHNUT_SELECT_TYPES.MAJOR);
   const { data: departmentData } = useDepartments();
   const departmentDict = useDepartmentDict(departmentData);
   const { doughnutData, totalCount } = useDoughnutData(data, departmentDict, majorName, selectedFilter);
@@ -55,7 +57,7 @@ function DepartmentDoughnut({ wishesInfo }: IDepartmentDoughnutProps) {
           value={selectedFilter}
           onChange={e => setSelectedFilter(e.target.value as DoughnutSelectType)}
         >
-          {Object.values(DoughnutSelectType).map(type => (
+          {Object.values(DOUGHNUT_SELECT_TYPES).map(type => (
             <option key={type} value={type}>
               {type}
             </option>
@@ -88,16 +90,16 @@ function useDoughnutData(
   const { universityDict, collegeDict } = departmentDict;
 
   switch (selectedFilter) {
-    case DoughnutSelectType.MAJOR:
+    case DOUGHNUT_SELECT_TYPES.MAJOR:
       doughnutData = getMajorDoughnutData(majorName, data);
       break;
-    case DoughnutSelectType.UNIVERSITY:
+    case DOUGHNUT_SELECT_TYPES.UNIVERSITY:
       doughnutData = getUniversityDoughnutData(data, universityDict);
       break;
-    case DoughnutSelectType.DEPARTMENT:
+    case DOUGHNUT_SELECT_TYPES.DEPARTMENT:
       doughnutData = getCollegeDoughnutData(data, collegeDict);
       break;
-    case DoughnutSelectType.COLLEGE:
+    case DOUGHNUT_SELECT_TYPES.COLLEGE:
       doughnutData = getDoughnutData(data);
       break;
     default:

--- a/packages/client/src/widgets/wishlist/DepartmentDoughnut.tsx
+++ b/packages/client/src/widgets/wishlist/DepartmentDoughnut.tsx
@@ -8,7 +8,7 @@ import {
   getMajorDoughnutData,
   getUniversityDoughnutData,
 } from '@/features/wish/lib/doughnut';
-import { WishesInfo } from '@/features/wish/model/useWishesInfo';
+import { WishesInfo } from '@/shared/model/types';
 import useDepartments, { DepartmentDict, useDepartmentDict } from '@/entities/departments/api/useDepartments.ts';
 import useDetailWishes from '@/entities/subjectAggregate/model/useDetailWishes';
 import useDetailRegisters from '@/entities/wishes/model/useDetailRegisters';

--- a/packages/client/src/widgets/wishlist/DepartmentDoughnut.tsx
+++ b/packages/client/src/widgets/wishlist/DepartmentDoughnut.tsx
@@ -8,19 +8,18 @@ import {
   getMajorDoughnutData,
   getUniversityDoughnutData,
 } from '@/features/wish/lib/doughnut';
-import { WishesInfo } from '@/shared/model/types';
-import useDepartments, { DepartmentDict, useDepartmentDict } from '@/entities/departments/api/useDepartments.ts';
+import type { IWishesInfo, WishRegister } from '@/shared/model/types';
+import useDepartments, { type DepartmentDict, useDepartmentDict } from '@/entities/departments/api/useDepartments';
 import useDetailWishes from '@/entities/subjectAggregate/model/useDetailWishes';
 import useDetailRegisters from '@/entities/wishes/model/useDetailRegisters';
 import { InitWishes } from '@/entities/wishes/model/useWishes';
 import LoadingWithMessage from '@/shared/ui/Loading';
-import { WishRegister } from '@/shared/model/types.ts';
 import { Flex, Heading, Label } from '@allcll/allcll-ui';
 
 ChartJS.register(ArcElement, Tooltip, Legend, BarElement, CategoryScale, LinearScale);
 
-interface DepartmentDoughnutProps {
-  wishesInfo: WishesInfo;
+interface IDepartmentDoughnutProps {
+  wishesInfo: IWishesInfo;
 }
 
 export enum DoughnutSelectType {
@@ -30,7 +29,7 @@ export enum DoughnutSelectType {
   COLLEGE = '학부',
 }
 
-function DepartmentDoughnut({ wishesInfo }: DepartmentDoughnutProps) {
+function DepartmentDoughnut({ wishesInfo }: IDepartmentDoughnutProps) {
   const { data: wishes, isPending } = useDetailWishes(wishesInfo);
   const { data: registers } = useDetailRegisters(wishesInfo);
 

--- a/packages/client/src/widgets/wishlist/RecommendWishes.tsx
+++ b/packages/client/src/widgets/wishlist/RecommendWishes.tsx
@@ -1,0 +1,38 @@
+import Table from '@/widgets/wishlist/Table';
+import { WishesInfo } from '@/features/wish/model/useWishesInfo';
+import useRecommendWishes from '@/entities/subjectAggregate/model/useRecommendWishes.ts';
+import { Heading, SupportingText } from '@allcll/allcll-ui';
+
+interface RecommendWishesProps {
+  wishesInfo: WishesInfo;
+}
+
+function RecommendWishes({ wishesInfo }: RecommendWishesProps) {
+  return (
+    <>
+      <Heading level={2} className="mt-2">
+        대체과목 추천
+      </Heading>
+      <SupportingText>학수번호가 같은 과목을 알려드려요</SupportingText>
+
+      <div className="overflow-x-auto">
+        <RecommendationTable wishesInfo={wishesInfo} />
+      </div>
+    </>
+  );
+}
+
+// Todo: 대체 과목 테이블, WishesTable 컴포넌트 합칠 수 있는지 확인
+// 대체과목 테이블 컴포넌트
+interface IRecommendationTableProps {
+  wishesInfo: WishesInfo;
+}
+
+function RecommendationTable({ wishesInfo }: IRecommendationTableProps) {
+  const { data: recommend } = useRecommendWishes(wishesInfo);
+  const placeholder = { title: '추천할 대체 과목이 없습니다.' };
+
+  return <Table data={recommend ?? []} placeholder={placeholder} />;
+}
+
+export default RecommendWishes;

--- a/packages/client/src/widgets/wishlist/RecommendWishes.tsx
+++ b/packages/client/src/widgets/wishlist/RecommendWishes.tsx
@@ -1,23 +1,21 @@
 import Table from '@/widgets/wishlist/Table';
-import { WishesInfo } from '@/shared/model/types';
-import useRecommendWishes from '@/entities/subjectAggregate/model/useRecommendWishes.ts';
-import { Heading, SupportingText } from '@allcll/allcll-ui';
+import type { IWishesInfo } from '@/shared/model/types';
+import useRecommendWishes from '@/entities/subjectAggregate/model/useRecommendWishes';
+import { Flex, Heading, SupportingText } from '@allcll/allcll-ui';
 
-interface RecommendWishesProps {
-  wishesInfo: WishesInfo;
+interface IRecommendWishesProps {
+  wishesInfo: IWishesInfo;
 }
 
-function RecommendWishes({ wishesInfo }: RecommendWishesProps) {
+function RecommendWishes({ wishesInfo }: IRecommendWishesProps) {
   return (
     <>
-      <Heading level={2} className="mt-2">
-        대체과목 추천
-      </Heading>
+      <Heading level={2}>대체과목 추천</Heading>
       <SupportingText>학수번호가 같은 과목을 알려드려요</SupportingText>
 
-      <div className="overflow-x-auto">
+      <Flex direction="flex-col" className="overflow-x-auto">
         <RecommendationTable wishesInfo={wishesInfo} />
-      </div>
+      </Flex>
     </>
   );
 }
@@ -25,7 +23,7 @@ function RecommendWishes({ wishesInfo }: RecommendWishesProps) {
 // Todo: 대체 과목 테이블, WishesTable 컴포넌트 합칠 수 있는지 확인
 // 대체과목 테이블 컴포넌트
 interface IRecommendationTableProps {
-  wishesInfo: WishesInfo;
+  wishesInfo: IWishesInfo;
 }
 
 function RecommendationTable({ wishesInfo }: IRecommendationTableProps) {

--- a/packages/client/src/widgets/wishlist/RecommendWishes.tsx
+++ b/packages/client/src/widgets/wishlist/RecommendWishes.tsx
@@ -1,5 +1,5 @@
 import Table from '@/widgets/wishlist/Table';
-import { WishesInfo } from '@/features/wish/model/useWishesInfo';
+import { WishesInfo } from '@/shared/model/types';
 import useRecommendWishes from '@/entities/subjectAggregate/model/useRecommendWishes.ts';
 import { Heading, SupportingText } from '@allcll/allcll-ui';
 

--- a/packages/client/src/widgets/wishlist/WishesBarChart.tsx
+++ b/packages/client/src/widgets/wishlist/WishesBarChart.tsx
@@ -39,9 +39,9 @@ function WishesBarChart({ wishesInfo }: WishesBarChartProps) {
       </Flex>
       <BlurComponents>
         <p className="text-sm text-gray-500">작년 대비 관심도 20% 증가 → 경쟁 치열할 가능성 높음</p>
-        <div className="mt-4">
+        <Flex direction="flex-col" className="mt-4">
           <Bar data={gradeData} />
-        </div>
+        </Flex>
       </BlurComponents>
     </>
   );

--- a/packages/client/src/widgets/wishlist/WishesBarChart.tsx
+++ b/packages/client/src/widgets/wishlist/WishesBarChart.tsx
@@ -1,8 +1,17 @@
-import BlurComponents from '@/shared/ui/BlurComponents.tsx';
 import { Bar } from 'react-chartjs-2';
 import { ArcElement, BarElement, CategoryScale, Chart as ChartJS, Legend, LinearScale, Tooltip } from 'chart.js/auto';
+import { WishesInfo } from '@/features/wish/model/useWishesInfo';
+import useDetailWishes from '@/entities/subjectAggregate/model/useDetailWishes';
+import { InitWishes } from '@/entities/wishes/model/useWishes';
+import BlurComponents from '@/shared/ui/BlurComponents.tsx';
+import { getWishesColor } from '@/shared/config/colors.ts';
+import { Flex, Heading } from '@allcll/allcll-ui';
 
 ChartJS.register(ArcElement, Tooltip, Legend, BarElement, CategoryScale, LinearScale);
+
+interface WishesBarChartProps {
+  wishesInfo: WishesInfo;
+}
 
 // 학년별 관심도 (막대 그래프)
 const gradeData = {
@@ -15,14 +24,26 @@ const gradeData = {
   ],
 };
 
-function WishesBarChart() {
+function WishesBarChart({ wishesInfo }: WishesBarChartProps) {
+  const { data: wishes } = useDetailWishes(wishesInfo);
+  const data = wishes ?? InitWishes;
+  const isWishesAvailable = wishes && 'totalCount' in wishes;
+
   return (
-    <BlurComponents>
-      <p className="text-sm text-gray-500">작년 대비 관심도 20% 증가 → 경쟁 치열할 가능성 높음</p>
-      <div className="mt-4">
-        <Bar data={gradeData} />
-      </div>
-    </BlurComponents>
+    <>
+      <Flex gap="gap-2" align="items-center" className="mb-4">
+        <Heading level={2}>관심과목 경쟁률 예상</Heading>
+        {isWishesAvailable && (
+          <p className={`${getWishesColor(data.totalCount ?? -1)} font-bold text-xl`}>총 {data.totalCount}명</p>
+        )}
+      </Flex>
+      <BlurComponents>
+        <p className="text-sm text-gray-500">작년 대비 관심도 20% 증가 → 경쟁 치열할 가능성 높음</p>
+        <div className="mt-4">
+          <Bar data={gradeData} />
+        </div>
+      </BlurComponents>
+    </>
   );
 }
 

--- a/packages/client/src/widgets/wishlist/WishesBarChart.tsx
+++ b/packages/client/src/widgets/wishlist/WishesBarChart.tsx
@@ -1,6 +1,6 @@
 import { Bar } from 'react-chartjs-2';
 import { ArcElement, BarElement, CategoryScale, Chart as ChartJS, Legend, LinearScale, Tooltip } from 'chart.js/auto';
-import { WishesInfo } from '@/features/wish/model/useWishesInfo';
+import { WishesInfo } from '@/shared/model/types';
 import useDetailWishes from '@/entities/subjectAggregate/model/useDetailWishes';
 import { InitWishes } from '@/entities/wishes/model/useWishes';
 import BlurComponents from '@/shared/ui/BlurComponents.tsx';

--- a/packages/client/src/widgets/wishlist/WishesBarChart.tsx
+++ b/packages/client/src/widgets/wishlist/WishesBarChart.tsx
@@ -1,16 +1,16 @@
 import { Bar } from 'react-chartjs-2';
 import { ArcElement, BarElement, CategoryScale, Chart as ChartJS, Legend, LinearScale, Tooltip } from 'chart.js/auto';
-import { WishesInfo } from '@/shared/model/types';
+import type { IWishesInfo } from '@/shared/model/types';
 import useDetailWishes from '@/entities/subjectAggregate/model/useDetailWishes';
 import { InitWishes } from '@/entities/wishes/model/useWishes';
-import BlurComponents from '@/shared/ui/BlurComponents.tsx';
-import { getWishesColor } from '@/shared/config/colors.ts';
+import BlurComponents from '@/shared/ui/BlurComponents';
+import { getWishesColor } from '@/shared/config/colors';
 import { Flex, Heading } from '@allcll/allcll-ui';
 
 ChartJS.register(ArcElement, Tooltip, Legend, BarElement, CategoryScale, LinearScale);
 
-interface WishesBarChartProps {
-  wishesInfo: WishesInfo;
+interface IWishesBarChartProps {
+  wishesInfo: IWishesInfo;
 }
 
 // 학년별 관심도 (막대 그래프)
@@ -24,7 +24,7 @@ const gradeData = {
   ],
 };
 
-function WishesBarChart({ wishesInfo }: WishesBarChartProps) {
+function WishesBarChart({ wishesInfo }: IWishesBarChartProps) {
   const { data: wishes } = useDetailWishes(wishesInfo);
   const data = wishes ?? InitWishes;
   const isWishesAvailable = wishes && 'totalCount' in wishes;

--- a/packages/client/src/widgets/wishlist/WishesDetailInfo.tsx
+++ b/packages/client/src/widgets/wishlist/WishesDetailInfo.tsx
@@ -1,6 +1,6 @@
 import FavoriteButton from '@/features/filtering/ui/button/FavoriteButton.tsx';
 import AlarmButton from '@/features/live/pin/ui/AlarmButton';
-import { WishesInfo } from '@/features/wish/model/useWishesInfo';
+import { WishesInfo } from '@/shared/model/types';
 import { InitWishes } from '@/entities/wishes/model/useWishes.ts';
 import SubjectDetail from '@/entities/subjects/ui/SubjectDetail.tsx';
 import useDetailWishes from '@/entities/subjectAggregate/model/useDetailWishes.ts';

--- a/packages/client/src/widgets/wishlist/WishesDetailInfo.tsx
+++ b/packages/client/src/widgets/wishlist/WishesDetailInfo.tsx
@@ -1,16 +1,16 @@
-import FavoriteButton from '@/features/filtering/ui/button/FavoriteButton.tsx';
+import FavoriteButton from '@/features/filtering/ui/button/FavoriteButton';
 import AlarmButton from '@/features/live/pin/ui/AlarmButton';
-import { WishesInfo } from '@/shared/model/types';
-import { InitWishes } from '@/entities/wishes/model/useWishes.ts';
-import SubjectDetail from '@/entities/subjects/ui/SubjectDetail.tsx';
-import useDetailWishes from '@/entities/subjectAggregate/model/useDetailWishes.ts';
+import type { IWishesInfo } from '@/shared/model/types';
+import { InitWishes } from '@/entities/wishes/model/useWishes';
+import SubjectDetail from '@/entities/subjects/ui/SubjectDetail';
+import useDetailWishes from '@/entities/subjectAggregate/model/useDetailWishes';
 import { Flex, Heading } from '@allcll/allcll-ui';
 
-interface WishesDetailInfoProps {
-  wishesInfo: WishesInfo;
+interface IWishesDetailInfoProps {
+  wishesInfo: IWishesInfo;
 }
 
-function WishesDetailInfo({ wishesInfo }: WishesDetailInfoProps) {
+function WishesDetailInfo({ wishesInfo }: IWishesDetailInfoProps) {
   const { data: wishes, isPending } = useDetailWishes(wishesInfo);
   const data = wishes ?? InitWishes;
 
@@ -33,15 +33,13 @@ function WishesDetailInfo({ wishesInfo }: WishesDetailInfoProps) {
   );
 }
 
-function InlineSkeleton({
-  isPending,
-  count = 1,
-  children,
-}: {
+interface IInlineSkeletonProps {
   isPending: boolean;
   count?: number;
   children: React.ReactNode;
-}) {
+}
+
+function InlineSkeleton({ isPending, count = 1, children }: IInlineSkeletonProps) {
   if (isPending) {
     return (
       <div className="animate-pulse">

--- a/packages/client/src/widgets/wishlist/WishesDetailInfo.tsx
+++ b/packages/client/src/widgets/wishlist/WishesDetailInfo.tsx
@@ -1,0 +1,58 @@
+import FavoriteButton from '@/features/filtering/ui/button/FavoriteButton.tsx';
+import AlarmButton from '@/features/live/pin/ui/AlarmButton';
+import { WishesInfo } from '@/features/wish/model/useWishesInfo';
+import { InitWishes } from '@/entities/wishes/model/useWishes.ts';
+import SubjectDetail from '@/entities/subjects/ui/SubjectDetail.tsx';
+import useDetailWishes from '@/entities/subjectAggregate/model/useDetailWishes.ts';
+import { Flex, Heading } from '@allcll/allcll-ui';
+
+interface WishesDetailInfoProps {
+  wishesInfo: WishesInfo;
+}
+
+function WishesDetailInfo({ wishesInfo }: WishesDetailInfoProps) {
+  const { data: wishes, isPending } = useDetailWishes(wishesInfo);
+  const data = wishes ?? InitWishes;
+
+  return (
+    <>
+      <Flex justify="justify-between" align="items-center">
+        <InlineSkeleton isPending={isPending}>
+          <Heading level={1}>{data.subjectName}</Heading>
+        </InlineSkeleton>
+
+        <Flex gap="gap-2">
+          <FavoriteButton subject={data} />
+          <AlarmButton subject={data} />
+        </Flex>
+      </Flex>
+      <InlineSkeleton isPending={isPending} count={3}>
+        <SubjectDetail wishes={wishes} />
+      </InlineSkeleton>
+    </>
+  );
+}
+
+function InlineSkeleton({
+  isPending,
+  count = 1,
+  children,
+}: {
+  isPending: boolean;
+  count?: number;
+  children: React.ReactNode;
+}) {
+  if (isPending) {
+    return (
+      <div className="animate-pulse">
+        {Array.from({ length: count }).map((_, i) => (
+          <div key={i} className="h-8 bg-gray-300 rounded w-1/3 mb-1" />
+        ))}
+      </div>
+    );
+  }
+
+  return children;
+}
+
+export default WishesDetailInfo;

--- a/packages/client/src/widgets/wishlist/WishesSemesterBanner.tsx
+++ b/packages/client/src/widgets/wishlist/WishesSemesterBanner.tsx
@@ -1,15 +1,15 @@
 import { useState } from 'react';
 import { Banner } from '@allcll/allcll-ui';
-import { WishesInfo } from '@/shared/model/types';
+import type { IWishesInfo } from '@/shared/model/types';
 
-interface WishesSemesterBannerProps {
-  wishesInfo: WishesInfo;
+interface IWishesSemesterBannerProps {
+  wishesInfo: IWishesInfo;
 }
 
-function WishesSemesterBanner({ wishesInfo }: WishesSemesterBannerProps) {
+function WishesSemesterBanner({ wishesInfo }: IWishesSemesterBannerProps) {
   const [showBanner, setShowBanner] = useState(true);
 
-  if (!wishesInfo.isLastSemesterWish || !showBanner) return null;
+  if (!wishesInfo.isPastSemester || !showBanner) return null;
 
   return (
     <Banner variant="warning" deleteBanner={() => setShowBanner(false)}>

--- a/packages/client/src/widgets/wishlist/WishesSemesterBanner.tsx
+++ b/packages/client/src/widgets/wishlist/WishesSemesterBanner.tsx
@@ -1,0 +1,21 @@
+import { useState } from 'react';
+import { Banner } from '@allcll/allcll-ui';
+import { WishesInfo } from '@/shared/model/types';
+
+interface WishesSemesterBannerProps {
+  wishesInfo: WishesInfo;
+}
+
+function WishesSemesterBanner({ wishesInfo }: WishesSemesterBannerProps) {
+  const [showBanner, setShowBanner] = useState(true);
+
+  if (!wishesInfo.isLastSemesterWish || !showBanner) return null;
+
+  return (
+    <Banner variant="warning" deleteBanner={() => setShowBanner(false)}>
+      {wishesInfo.semesterValue}학기의 과목 입니다. 수강 신청에 유의해주세요.
+    </Banner>
+  );
+}
+
+export default WishesSemesterBanner;


### PR DESCRIPTION
## 작업 내용
- 이전 학기의 과목도 관심과목 분석 상세 페이지를 볼 수 있도록 수정
  - 이번 학기 과목은 관심과목 분석 상세 (wishes detail)페이지에서 접근이 되지만, 이전 학기에 대한 과목은 정보가 없어서 나오지 않음. [예시는 다음과 같습니다](https://dev.allcll.kr/wishes/4225)
- wishesDetail page 페이지에 맞도록 코드 리펙토링
  - wishesInfo 로 input 값을 따로 분리하여 DI (의존성 주입) 방식으로 변경
  - 컴포넌트 분리 - widget
  - pendding 및 에러처리
- 404 에러 시, 페이지 없음 나오도록 수정

## 변경 사항 및 리뷰 포인트
- 학기별 subjectId 관리 기능 추가 ([packages/client/src/entities/semester/model/useSemesterNameBySubjectId.ts](https://github.com/allcll/allcll-frontend/pull/348/files#diff-1c4448d8c7eb2adc0cd3dd99c1a2a3d4103b72142267968841f64db3064d4825))
- useWishes, useDetailWishes 에 semesterCode 추가
- wishesInfo 타입 추가 ([packages/client/src/features/wish/model/useWishesInfo.ts](https://github.com/allcll/allcll-frontend/pull/348/files#diff-2540964ecd52342ac30c9b6c4187943791e33827a45f7c2702523f37420a3e7d))
  - subjectId 와 semesterCode 등 hook 에 넣어줘야 하는데, 훅의 파라미터가 변경사항이 발생하면 고쳐야 할 부분이 많이 발생합니다. 이 문제를 해결하기 위해서 input 을 통합하기 위한 타입을 추가했습니다.
- 코드 가독성 측면에서 더 좋은 방법이 있다면 편하게 의견 주셔도 좋습니다.

## 추후 추가하면 좋은 issue
- 내부 컴포넌트에서 throw 를 했을 때, 상위 컴포넌트에서 error 를 감지할 방법이 없음.
  - page 에서는 컴포넌트에서 error 를 throw 할 때 감지할 수 있는 방법이 없음.
- API 에 대한 Error 처리가 공통적으로 정의 되어있지 않음.
  - 어디는 404, 어디는 400 만 예외처리 되도록 되어있음.

<img width="799" height="786" alt="image" src="https://github.com/user-attachments/assets/18791d0d-bb13-4662-ab99-947494822303" />

