### PR TITLE
chore: parallelize client and admin builds in gh actions

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -16,73 +16,74 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  client-build:
+  build:
     runs-on: ubuntu-latest
     env:
       working-directory: ./
-      project-directory: ./packages/client
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: '24'
+          cache: 'pnpm'
+
+      - name: Install pnpm
+        run: npm install -g pnpm
 
       - name: Install NPM packages
-        run: |
-          npm install -g pnpm
-          pnpm i --frozen-lockfile
+        run: pnpm i --frozen-lockfile
         working-directory: ${{env.working-directory}}
 
-      - name: Build Client project
+      - name: Build Projects in Parallel
         run: |
-          pnpm run build-client
-          cd ${{env.project-directory}}
-          mkdir -p ./build
-          cp -r dist ./build
-          cp package.json ./build/package.json
-        #          cp pnpm-lock.yaml ./build/pnpm-lock.yaml
-        env:
-          CI: ''
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-          VITE_SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
-          VITE_GOOGLE_ANALYTICS_ID: ${{ secrets.GOOGLE_ANALYTICS_ID }}
-          VITE_CLARITY_PROJECT_ID: ${{ secrets.CLARITY_PROJECT_ID }}
-          VITE_AMPLITUDE_API_KEY: ${{ secrets.AMPLITUDE_API_KEY }}
-          VITE_SUPABASE_URL: ${{ secrets.MAIN_SUPABASE_URL }}
-          VITE_SUPABASE_ANON_KEY: ${{ secrets.MAIN_SUPABASE_ANON_KEY }}
-          VITE_SUPABASE_TABLE_NAME: ${{ secrets.MAIN_SUPABASE_TABLE_NAME }}
-          VITE_DEV_SERVER: false
+          (
+            export VITE_SENTRY_DSN="${{ secrets.SENTRY_DSN }}"
+            export VITE_GOOGLE_ANALYTICS_ID="${{ secrets.GOOGLE_ANALYTICS_ID }}"
+            export VITE_CLARITY_PROJECT_ID="${{ secrets.CLARITY_PROJECT_ID }}"
+            export VITE_AMPLITUDE_API_KEY="${{ secrets.AMPLITUDE_API_KEY }}"
+            export VITE_SUPABASE_URL="${{ secrets.MAIN_SUPABASE_URL }}"
+            export VITE_SUPABASE_ANON_KEY="${{ secrets.MAIN_SUPABASE_ANON_KEY }}"
+            export VITE_SUPABASE_TABLE_NAME="${{ secrets.MAIN_SUPABASE_TABLE_NAME }}"
+            export SENTRY_AUTH_TOKEN="${{ secrets.SENTRY_AUTH_TOKEN }}"
+            export VITE_DEV_SERVER=false
+            export CI=''
+            pnpm run build-client
+            cd ./packages/client
+            mkdir -p ./build
+            cp -r dist ./build
+            cp package.json ./build/package.json
+          ) &
+          (
+            pnpm run build-admin
+          ) &
+          wait
         working-directory: ${{env.working-directory}}
 
-      #    - name: Run tests
-      #      run: npm run test
-      #      working-directory: ${{env.working-directory}}
-
-      - name: Upload production-ready build files
+      - name: Upload Client build files
         uses: actions/upload-artifact@v4
         with:
           name: production-files
-          path: ${{env.project-directory}}/build
+          path: ./packages/client/build
 
-      - name: Download artifact
-        uses: actions/download-artifact@v4
+      - name: Upload Admin build files
+        uses: actions/upload-artifact@v4
         with:
-          name: production-files
-          path: ./build
+          name: admin-build-files
+          path: ./packages/admin/dist
 
-      - name: Deploy to gh-pages
+      - name: Deploy Client to gh-pages
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ${{env.project-directory}}/build
+          publish_dir: ./packages/client/build
 
   client-deploy:
     runs-on: ubuntu-latest
-    needs: client-build
+    needs: build
 
     steps:
       - name: executing remote ssh commands using ssh key
@@ -99,44 +100,9 @@ jobs:
             sudo systemctl reload nginx
             # 필요한 cmd 명령어 사용
 
-### Admin page 배포
-
-  admin-build:
-    runs-on: ubuntu-latest
-    env:
-      working-directory: ./
-      project-directory: ./packages/admin
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Install Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '24'
-
-      - name: Install NPM packages
-        run: |
-          npm install -g pnpm
-          pnpm i --frozen-lockfile
-        working-directory: ${{env.working-directory}}
-
-      - name: Build Admin project
-        run: |
-          pnpm run build-admin
-          cd ${{env.project-directory}}
-        working-directory: ${{env.working-directory}}
-
-      - name: Upload production-ready build files
-        uses: actions/upload-artifact@v4
-        with:
-          name: admin-build-files
-          path: ${{env.project-directory}}/dist
-
   admin-deploy:
     runs-on: ubuntu-latest
-    needs: admin-build
+    needs: build
 
     steps:
       - uses: actions/download-artifact@v4
@@ -151,7 +117,7 @@ jobs:
           username: ${{ secrets.USERNAME }}
           key: ${{ secrets.MAIN_SERVER_SSH_KEY }}
           port: 22
-          source: admin/* # 파일 이름으로 압축이 풀림. -> 이전 경로에서 풀어야 합쳐짐
+          source: admin/*
           target: ${{secrets.PWD}} # 원격 서버의 배포 경로
 
       - name: deploy - executing remote ssh commands using ssh key

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -25,14 +25,16 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '24'
           cache: 'pnpm'
-
-      - name: Install pnpm
-        run: npm install -g pnpm
 
       - name: Install NPM packages
         run: pnpm i --frozen-lockfile

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -75,38 +75,11 @@ jobs:
           name: admin-build-files
           path: ./packages/admin/dist
 
-  client-gh-pages-deploy:
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - name: Download Client Artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: production-files
-          path: production-files
-
       - name: Deploy Client to gh-pages
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: production-files
-
-  deploy:
-    runs-on: ubuntu-latest
-    needs: build
-
-    steps:
-      - name: Download Client Artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: production-files
-          path: production-files
-
-      - name: Download Admin Artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: admin-build-files
-          path: admin-dist
+          publish_dir: ./packages/client/build
 
       - name: executing remote ssh commands using ssh key
         uses: appleboy/ssh-action@v1
@@ -128,9 +101,9 @@ jobs:
           username: ${{ secrets.USERNAME }}
           key: ${{ secrets.MAIN_SERVER_SSH_KEY }}
           port: 22
-          source: admin-dist/*
+          source: packages/admin/dist/*
           target: ${{secrets.PWD}}/admin
-          strip_components: 1
+          strip_components: 3
 
       - name: deploy - executing remote ssh commands using ssh key
         uses: appleboy/ssh-action@v1

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -27,8 +27,6 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: Install Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -75,11 +75,21 @@ jobs:
           name: admin-build-files
           path: ./packages/admin/dist
 
+  client-gh-pages-deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Download Client Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: production-files
+          path: production-files
+
       - name: Deploy Client to gh-pages
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./packages/client/build
+          publish_dir: production-files
 
   client-deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -91,11 +91,23 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: production-files
 
-  client-deploy:
+  deploy:
     runs-on: ubuntu-latest
     needs: build
 
     steps:
+      - name: Download Client Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: production-files
+          path: production-files
+
+      - name: Download Admin Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: admin-build-files
+          path: admin-dist
+
       - name: executing remote ssh commands using ssh key
         uses: appleboy/ssh-action@v1
         with:
@@ -108,27 +120,17 @@ jobs:
             cd ${{ secrets.PWD }}/frontend
             sudo git pull https://${{ secrets.GIT_TOKEN }}:x-oauth-basic@github.com/allcll/frontend.git gh-pages
             sudo systemctl reload nginx
-            # 필요한 cmd 명령어 사용
 
-  admin-deploy:
-    runs-on: ubuntu-latest
-    needs: build
-
-    steps:
-      - uses: actions/download-artifact@v4
-        with:
-          name: admin-build-files
-          path: admin
-
-      - name: Copy files to Server via SCP
+      - name: Copy Admin files to Server via SCP
         uses: appleboy/scp-action@v1
         with:
           host: ${{ secrets.MAIN_SERVER_HOST }}
           username: ${{ secrets.USERNAME }}
           key: ${{ secrets.MAIN_SERVER_SSH_KEY }}
           port: 22
-          source: admin/*
-          target: ${{secrets.PWD}} # 원격 서버의 배포 경로
+          source: admin-dist/*
+          target: ${{secrets.PWD}}/admin
+          strip_components: 1
 
       - name: deploy - executing remote ssh commands using ssh key
         uses: appleboy/ssh-action@v1

--- a/.github/workflows/dev-build-deploy.yml
+++ b/.github/workflows/dev-build-deploy.yml
@@ -15,11 +15,10 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  client-dev-ci:
+  build:
     runs-on: ubuntu-latest
     env:
       working-directory: ./
-      project-directory: ./packages/client
 
     steps:
       - name: Checkout code
@@ -29,41 +28,54 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '24'
+          cache: 'pnpm'
+
+      - name: Install pnpm
+        run: npm install -g pnpm
 
       - name: Install NPM packages
-        run: |
-          npm install -g pnpm
-          pnpm i --frozen-lockfile
+        run: pnpm i --frozen-lockfile
         working-directory: ${{env.working-directory}}
 
-      - name: Build Client project
+      - name: Build Projects in Parallel
         run: |
-          pnpm run build-client
-          cd ${{env.project-directory}}
-        env:
-          VITE_SUPABASE_URL: ${{ secrets.DEV_SUPABASE_URL }}
-          VITE_SUPABASE_ANON_KEY: ${{ secrets.DEV_SUPABASE_ANON_KEY }}
-          VITE_SUPABASE_TABLE_NAME: ${{ secrets.DEV_SUPABASE_TABLE_NAME }}
-          VITE_API_BASE_URL: ${{ secrets.DEV_API_BASE_URL }}
-          VITE_DEV_SERVER: true
+          (
+            export VITE_SUPABASE_URL="${{ secrets.DEV_SUPABASE_URL }}"
+            export VITE_SUPABASE_ANON_KEY="${{ secrets.DEV_SUPABASE_ANON_KEY }}"
+            export VITE_SUPABASE_TABLE_NAME="${{ secrets.DEV_SUPABASE_TABLE_NAME }}"
+            export VITE_API_BASE_URL="${{ secrets.DEV_API_BASE_URL }}"
+            export VITE_DEV_SERVER=true
+            pnpm -F @allcll/client run build
+          ) &
+          (
+            export VITE_DEV_SERVER=true
+            pnpm -F @allcll/admin run build
+          ) &
+          wait
         working-directory: ${{env.working-directory}}
 
-      - name: Upload production-ready build files
+      - name: Upload Client build files
         uses: actions/upload-artifact@v4
         with:
           name: development-files
-          path: ${{env.project-directory}}/dist
+          path: ./packages/client/dist
 
-      - name: Deploy to gh-pages
+      - name: Upload Admin build files
+        uses: actions/upload-artifact@v4
+        with:
+          name: admin-development-files
+          path: ./packages/admin/dist
+
+      - name: Deploy Client to gh-pages
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ${{env.project-directory}}/dist
+          publish_dir: ./packages/client/dist
           publish_branch: 'gh-dev-pages'
 
   client-dev-deploy:
     runs-on: ubuntu-latest
-    needs: client-dev-ci
+    needs: build
 
     steps:
       - name: executing remote ssh commands using ssh key
@@ -115,46 +127,9 @@ jobs:
           path: playwright-report/
           retention-days: 30
 
-  ######## Admin Dev Build and Deploy ########
-
-  admin-dev-ci:
-    runs-on: ubuntu-latest
-    env:
-      working-directory: ./
-      project-directory: ./packages/admin
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Install Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '24'
-
-      - name: Install NPM packages
-        run: |
-          npm install -g pnpm
-          pnpm i --frozen-lockfile
-        working-directory: ${{env.working-directory}}
-
-      - name: Build Client project
-        run: |
-          pnpm run build-admin
-          # cd ${{env.project-directory}}
-        env:
-          VITE_DEV_SERVER: true
-        working-directory: ${{env.working-directory}}
-
-      - name: Upload production-ready build files
-        uses: actions/upload-artifact@v4
-        with:
-          name: admin-development-files
-          path: ${{env.project-directory}}/dist
-
   admin-dev-cd:
     runs-on: ubuntu-latest
-    needs: admin-dev-ci
+    needs: build
 
     steps:
       - uses: actions/download-artifact@v4

--- a/.github/workflows/dev-build-deploy.yml
+++ b/.github/workflows/dev-build-deploy.yml
@@ -24,14 +24,16 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '24'
           cache: 'pnpm'
-
-      - name: Install pnpm
-        run: npm install -g pnpm
 
       - name: Install NPM packages
         run: pnpm i --frozen-lockfile

--- a/.github/workflows/dev-build-deploy.yml
+++ b/.github/workflows/dev-build-deploy.yml
@@ -66,27 +66,11 @@ jobs:
           name: admin-development-files
           path: ./packages/admin/dist
 
-  deploy:
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - name: Download Client Artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: development-files
-          path: development-files
-
-      - name: Download Admin Artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: admin-development-files
-          path: admin-development-files
-
       - name: Deploy Client to gh-pages
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: development-files
+          publish_dir: ./packages/client/dist
           publish_branch: 'gh-dev-pages'
 
       - name: executing remote ssh commands using ssh key
@@ -108,9 +92,9 @@ jobs:
           username: ${{ secrets.USERNAME }}
           key: ${{ secrets.DEV_SERVER_SSH_KEY }}
           port: 22
-          source: admin-development-files/*
+          source: packages/admin/dist/*
           target: ${{secrets.PWD}}/admin
-          strip_components: 1
+          strip_components: 3
 
       - name: Reload Admin Nginx
         uses: appleboy/ssh-action@v1
@@ -124,7 +108,7 @@ jobs:
 
   client-test:
     runs-on: ubuntu-latest
-    needs: deploy
+    needs: build
     timeout-minutes: 15
 
 

--- a/.github/workflows/dev-build-deploy.yml
+++ b/.github/workflows/dev-build-deploy.yml
@@ -26,8 +26,6 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: Install Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/dev-build-deploy.yml
+++ b/.github/workflows/dev-build-deploy.yml
@@ -66,11 +66,21 @@ jobs:
           name: admin-development-files
           path: ./packages/admin/dist
 
+  client-gh-pages-deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Download Client Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: development-files
+          path: development-files
+
       - name: Deploy Client to gh-pages
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./packages/client/dist
+          publish_dir: development-files
           publish_branch: 'gh-dev-pages'
 
   client-dev-deploy:

--- a/.github/workflows/dev-build-deploy.yml
+++ b/.github/workflows/dev-build-deploy.yml
@@ -66,7 +66,7 @@ jobs:
           name: admin-development-files
           path: ./packages/admin/dist
 
-  client-gh-pages-deploy:
+  deploy:
     runs-on: ubuntu-latest
     needs: build
     steps:
@@ -76,6 +76,12 @@ jobs:
           name: development-files
           path: development-files
 
+      - name: Download Admin Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: admin-development-files
+          path: admin-development-files
+
       - name: Deploy Client to gh-pages
         uses: peaceiris/actions-gh-pages@v3
         with:
@@ -83,81 +89,30 @@ jobs:
           publish_dir: development-files
           publish_branch: 'gh-dev-pages'
 
-  client-dev-deploy:
-    runs-on: ubuntu-latest
-    needs: build
-
-    steps:
       - name: executing remote ssh commands using ssh key
         uses: appleboy/ssh-action@v1
         with:
           host: ${{ secrets.DEV_SERVER_HOST }}
           username: ${{ secrets.USERNAME }}
           key: ${{ secrets.DEV_SERVER_SSH_KEY }}
-          #passphrase: ${{ secrets.PASSPHRASE }}
           port: 22
           script: |
             cd ${{ secrets.PWD }}/client
             sudo git pull https://${{ secrets.GIT_TOKEN }}:x-oauth-basic@github.com/allcll/frontend.git gh-dev-pages
             sudo systemctl reload nginx
-            # 필요한 cmd 명령어 사용
 
-
-  client-test:
-    runs-on: ubuntu-latest
-    needs: client-dev-deploy
-    timeout-minutes: 15
-
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: lts/*
-
-      - name: Install NPM packages
-        run: |
-          npm install -g pnpm
-          pnpm i --frozen-lockfile
-
-      - name: Install Playwright Browsers
-        run: |
-          cd ./packages/e2e
-          npx playwright install --with-deps
-      - name: Run Playwright tests
-        run: |
-          pnpm run test
-        env:
-          VITE_TEST_ENV: ${{ secrets.DEV_TEST_ENV }}
-          # Add any other environment variables needed for your tests here
-
-      - uses: actions/upload-artifact@v4
-        if: ${{ !cancelled() }}
-        with:
-          name: playwright-report
-          path: playwright-report/
-          retention-days: 30
-
-  admin-dev-cd:
-    runs-on: ubuntu-latest
-    needs: build
-
-    steps:
-      - uses: actions/download-artifact@v4
-        with:
-          name: admin-development-files
-          path: admin
-
-      - name: Copy files to Server via SCP
+      - name: Copy Admin files to Server via SCP
         uses: appleboy/scp-action@v1
         with:
           host: ${{ secrets.DEV_SERVER_HOST }}
           username: ${{ secrets.USERNAME }}
           key: ${{ secrets.DEV_SERVER_SSH_KEY }}
           port: 22
-          source: admin/*
-          target: ${{secrets.PWD}} # 원격 서버의 배포 경로
+          source: admin-development-files/*
+          target: ${{secrets.PWD}}/admin
+          strip_components: 1
 
-      - name: deploy - executing remote ssh commands using ssh key
+      - name: Reload Admin Nginx
         uses: appleboy/ssh-action@v1
         with:
           host: ${{ secrets.DEV_SERVER_HOST }}
@@ -166,6 +121,11 @@ jobs:
           port: 22
           script: |
             sudo systemctl reload nginx
+
+  client-test:
+    runs-on: ubuntu-latest
+    needs: deploy
+    timeout-minutes: 15
 
 
 ### Deployment to Cloudfront

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -17,8 +17,6 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: Install Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      pull-requests: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -15,14 +15,16 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '24'
           cache: 'pnpm'
-
-      - name: Install pnpm
-        run: npm install -g pnpm
 
       - name: Install dependencies
         run: pnpm i --frozen-lockfile

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -61,25 +61,6 @@ jobs:
           name: admin-dist
           path: packages/admin/dist
 
-  deploy-preview:
-    if: github.event.action != 'closed'
-    needs: build
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-    steps:
-      - name: Download Client Artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: client-dist
-          path: client-dist
-
-      - name: Download Admin Artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: admin-dist
-          path: admin-dist
-
       - name: Deploy Client preview to server
         uses: appleboy/scp-action@v1
         with:
@@ -87,9 +68,9 @@ jobs:
           username: ${{ secrets.USERNAME }}
           key: ${{ secrets.DEV_SERVER_SSH_KEY }}
           port: 22
-          source: client-dist/*
+          source: packages/client/dist/*
           target: ${{ secrets.PWD }}/clients/pr-${{ github.event.pull_request.number }}
-          strip_components: 1
+          strip_components: 3
 
       - name: Deploy Admin preview to server
         uses: appleboy/scp-action@v1
@@ -98,9 +79,9 @@ jobs:
           username: ${{ secrets.USERNAME }}
           key: ${{ secrets.DEV_SERVER_SSH_KEY }}
           port: 22
-          source: admin-dist/*
+          source: packages/admin/dist/*
           target: ${{ secrets.PWD }}/admins/pr-${{ github.event.pull_request.number }}
-          strip_components: 1
+          strip_components: 3
 
       - name: Reload Nginx
         uses: appleboy/ssh-action@v1

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -6,7 +6,7 @@ on:
     types: [opened, synchronize, reopened, closed]
 
 jobs:
-  build-client:
+  build:
     if: github.event.action != 'closed'
     runs-on: ubuntu-latest
     permissions:
@@ -19,6 +19,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '24'
+          cache: 'pnpm'
 
       - name: Install pnpm
         run: npm install -g pnpm
@@ -26,51 +27,33 @@ jobs:
       - name: Install dependencies
         run: pnpm i --frozen-lockfile
 
-      - name: Build Client for Preview
-        run: pnpm -F @allcll/client run build
-        env:
-          VITE_BASE: /pr-${{ github.event.pull_request.number }}/
-          VITE_SUPABASE_URL: ${{ secrets.DEV_SUPABASE_URL }}
-          VITE_SUPABASE_ANON_KEY: ${{ secrets.DEV_SUPABASE_ANON_KEY }}
-          VITE_SUPABASE_TABLE_NAME: ${{ secrets.DEV_SUPABASE_TABLE_NAME }}
-          VITE_API_BASE_URL: ${{ secrets.DEV_API_BASE_URL }}
-          VITE_DEV_SERVER: true
+      - name: Build Projects for Preview in Parallel
+        run: |
+          (
+            export VITE_BASE=/pr-${{ github.event.pull_request.number }}/
+            export VITE_SUPABASE_URL="${{ secrets.DEV_SUPABASE_URL }}"
+            export VITE_SUPABASE_ANON_KEY="${{ secrets.DEV_SUPABASE_ANON_KEY }}"
+            export VITE_SUPABASE_TABLE_NAME="${{ secrets.DEV_SUPABASE_TABLE_NAME }}"
+            export VITE_API_BASE_URL="${{ secrets.DEV_API_BASE_URL }}"
+            export VITE_DEV_SERVER=true
+            pnpm -F @allcll/client run build
+          ) &
+          (
+            export VITE_BASE=/pr-${{ github.event.pull_request.number }}/
+            export VITE_SUPABASE_URL="${{ secrets.DEV_SUPABASE_URL }}"
+            export VITE_SUPABASE_ANON_KEY="${{ secrets.DEV_SUPABASE_ANON_KEY }}"
+            export VITE_SUPABASE_TABLE_NAME="${{ secrets.DEV_SUPABASE_TABLE_NAME }}"
+            export VITE_API_BASE_URL="${{ secrets.DEV_API_BASE_URL }}"
+            export VITE_DEV_SERVER=true
+            pnpm -F @allcll/admin run build
+          ) &
+          wait
       
       - name: Upload Client Artifact
         uses: actions/upload-artifact@v4
         with:
           name: client-dist
           path: packages/client/dist
-
-  build-admin:
-    if: github.event.action != 'closed'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Install Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '24'
-
-      - name: Install pnpm
-        run: npm install -g pnpm
-
-      - name: Install dependencies
-        run: pnpm i --frozen-lockfile
-
-      - name: Build Admin for Preview
-        run: pnpm -F @allcll/admin run build
-        env:
-          VITE_BASE: /pr-${{ github.event.pull_request.number }}/
-          VITE_SUPABASE_URL: ${{ secrets.DEV_SUPABASE_URL }}
-          VITE_SUPABASE_ANON_KEY: ${{ secrets.DEV_SUPABASE_ANON_KEY }}
-          VITE_SUPABASE_TABLE_NAME: ${{ secrets.DEV_SUPABASE_TABLE_NAME }}
-          VITE_API_BASE_URL: ${{ secrets.DEV_API_BASE_URL }}
-          VITE_DEV_SERVER: true
 
       - name: Upload Admin Artifact
         uses: actions/upload-artifact@v4
@@ -80,7 +63,7 @@ jobs:
 
   deploy-preview:
     if: github.event.action != 'closed'
-    needs: [build-client, build-admin]
+    needs: build
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -61,24 +61,16 @@ jobs:
           name: admin-dist
           path: packages/admin/dist
 
-  deploy-preview:
+  deploy-client-preview:
     if: github.event.action != 'closed'
     needs: build
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
     steps:
       - name: Download Client Artifact
         uses: actions/download-artifact@v4
         with:
           name: client-dist
           path: client-dist
-
-      - name: Download Admin Artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: admin-dist
-          path: admin-dist
 
       - name: Deploy Client preview to server
         uses: appleboy/scp-action@v1
@@ -90,6 +82,26 @@ jobs:
           source: client-dist/*
           target: ${{ secrets.PWD }}/clients/pr-${{ github.event.pull_request.number }}
           strip_components: 1
+
+      - name: Reload Nginx
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.DEV_SERVER_HOST }}
+          username: ${{ secrets.USERNAME }}
+          key: ${{ secrets.DEV_SERVER_SSH_KEY }}
+          port: 22
+          script: sudo systemctl reload nginx
+
+  deploy-admin-preview:
+    if: github.event.action != 'closed'
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download Admin Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: admin-dist
+          path: admin-dist
 
       - name: Deploy Admin preview to server
         uses: appleboy/scp-action@v1
@@ -111,6 +123,13 @@ jobs:
           port: 22
           script: sudo systemctl reload nginx
 
+  comment-preview:
+    if: github.event.action != 'closed'
+    needs: [deploy-client-preview, deploy-admin-preview]
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
       - name: Comment preview URL on PR
         uses: actions/github-script@v7
         env:

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -61,16 +61,24 @@ jobs:
           name: admin-dist
           path: packages/admin/dist
 
-  deploy-client-preview:
+  deploy-preview:
     if: github.event.action != 'closed'
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - name: Download Client Artifact
         uses: actions/download-artifact@v4
         with:
           name: client-dist
           path: client-dist
+
+      - name: Download Admin Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: admin-dist
+          path: admin-dist
 
       - name: Deploy Client preview to server
         uses: appleboy/scp-action@v1
@@ -82,26 +90,6 @@ jobs:
           source: client-dist/*
           target: ${{ secrets.PWD }}/clients/pr-${{ github.event.pull_request.number }}
           strip_components: 1
-
-      - name: Reload Nginx
-        uses: appleboy/ssh-action@v1
-        with:
-          host: ${{ secrets.DEV_SERVER_HOST }}
-          username: ${{ secrets.USERNAME }}
-          key: ${{ secrets.DEV_SERVER_SSH_KEY }}
-          port: 22
-          script: sudo systemctl reload nginx
-
-  deploy-admin-preview:
-    if: github.event.action != 'closed'
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Download Admin Artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: admin-dist
-          path: admin-dist
 
       - name: Deploy Admin preview to server
         uses: appleboy/scp-action@v1
@@ -123,13 +111,6 @@ jobs:
           port: 22
           script: sudo systemctl reload nginx
 
-  comment-preview:
-    if: github.event.action != 'closed'
-    needs: [deploy-client-preview, deploy-admin-preview]
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-    steps:
       - name: Comment preview URL on PR
         uses: actions/github-script@v7
         env:


### PR DESCRIPTION
### 작업 내용
- GitHub Actions에서 client와 admin 빌드 프로세스를 병렬화하여 전체 빌드 시간 단축
- 단일 runner 내에서 멀티코어를 활용하여 리소스 효율성 증대
- pnpm 캐싱 도입으로 의존성 설치 속도 개선

### 변경 사항 및 리뷰 포인트
- dev-build-deploy.yml, build-deploy.yml, pr-ci.yml 파일에서 분리되어 있던 build job들을 하나로 통합
- 백그라운드 프로세스(&)와 wait 명령어를 사용하여 빌드 병렬 실행 구성
- actions/setup-node에 cache: 'pnpm' 추가