### PR TITLE
feat: GitHub Deployment 공식 연동 및 배포 리포트 자동화

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -106,9 +106,11 @@ jobs:
       - name: Deployment Report (Client)
         if: always()
         uses: actions/github-script@v7
+        env:
+          JOB_STATUS: ${{ job.status }}
         with:
           script: |
-            const status = '${{ job.status }}';
+            const status = process.env.JOB_STATUS;
             const getStatusEmoji = (s) => s === 'success' ? '✅' : '❌';
             const body = `### 🚀 Client Production Deployment\n- **Status:** ${getStatusEmoji(status)} ${status}\n- **URL:** [https://allcll.kr](https://allcll.kr)\n- **Commit:** ${context.sha.substring(0, 7)}`;
             core.summary.addRaw(body).write();
@@ -184,9 +186,11 @@ jobs:
       - name: Deployment Report (Admin)
         if: always()
         uses: actions/github-script@v7
+        env:
+          JOB_STATUS: ${{ job.status }}
         with:
           script: |
-            const status = '${{ job.status }}';
+            const status = process.env.JOB_STATUS;
             const getStatusEmoji = (s) => s === 'success' ? '✅' : '❌';
             const body = `### 🚀 Admin Production Deployment\n- **Status:** ${getStatusEmoji(status)} ${status}\n- **URL:** [https://admin.allcll.kr](https://admin.allcll.kr)\n- **Commit:** ${context.sha.substring(0, 7)}`;
             core.summary.addRaw(body).write();

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -8,7 +8,6 @@ permissions:
   contents: write
   pages: write
   id-token: write
-  deployments: write
 
 # ssh 이용한 빌드 및 배포
 # Allow one concurrent deployment
@@ -84,9 +83,6 @@ jobs:
   client-deploy:
     runs-on: ubuntu-latest
     needs: client-build
-    environment:
-      name: production-client
-      url: https://allcll.kr
 
     steps:
       - name: executing remote ssh commands using ssh key
@@ -159,9 +155,6 @@ jobs:
   admin-deploy:
     runs-on: ubuntu-latest
     needs: admin-build
-    environment:
-      name: production-admin
-      url: https://admin.allcll.kr
 
     steps:
       - uses: actions/download-artifact@v4

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -8,6 +8,7 @@ permissions:
   contents: write
   pages: write
   id-token: write
+  deployments: write
 
 # ssh 이용한 빌드 및 배포
 # Allow one concurrent deployment
@@ -83,6 +84,9 @@ jobs:
   client-deploy:
     runs-on: ubuntu-latest
     needs: client-build
+    environment:
+      name: production-client
+      url: https://allcll.kr
 
     steps:
       - name: executing remote ssh commands using ssh key
@@ -98,6 +102,24 @@ jobs:
             sudo git pull https://${{ secrets.GIT_TOKEN }}:x-oauth-basic@github.com/allcll/frontend.git gh-pages
             sudo systemctl reload nginx
             # 필요한 cmd 명령어 사용
+
+      - name: Deployment Report (Client)
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const status = '${{ job.status }}';
+            const getStatusEmoji = (s) => s === 'success' ? '✅' : '❌';
+            const body = `### 🚀 Client Production Deployment\n- **Status:** ${getStatusEmoji(status)} ${status}\n- **URL:** [https://allcll.kr](https://allcll.kr)\n- **Commit:** ${context.sha.substring(0, 7)}`;
+            core.summary.addRaw(body).write();
+            try {
+              await github.rest.repos.createCommitComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                commit_sha: context.sha,
+                body: body
+              });
+            } catch (e) {}
 
 ### Admin page 배포
 
@@ -137,6 +159,9 @@ jobs:
   admin-deploy:
     runs-on: ubuntu-latest
     needs: admin-build
+    environment:
+      name: production-admin
+      url: https://admin.allcll.kr
 
     steps:
       - uses: actions/download-artifact@v4
@@ -163,6 +188,24 @@ jobs:
           port: 22
           script: |
             sudo systemctl reload nginx
+
+      - name: Deployment Report (Admin)
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const status = '${{ job.status }}';
+            const getStatusEmoji = (s) => s === 'success' ? '✅' : '❌';
+            const body = `### 🚀 Admin Production Deployment\n- **Status:** ${getStatusEmoji(status)} ${status}\n- **URL:** [https://admin.allcll.kr](https://admin.allcll.kr)\n- **Commit:** ${context.sha.substring(0, 7)}`;
+            core.summary.addRaw(body).write();
+            try {
+              await github.rest.repos.createCommitComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                commit_sha: context.sha,
+                body: body
+              });
+            } catch (e) {}
 
 
 # cloudfront 배포

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -8,6 +8,7 @@ permissions:
   contents: write
   pages: write
   id-token: write
+  deployments: write
 
 # ssh 이용한 빌드 및 배포
 # Allow one concurrent deployment
@@ -83,6 +84,9 @@ jobs:
   client-deploy:
     runs-on: ubuntu-latest
     needs: client-build
+    environment:
+      name: production
+      url: https://allcll.kr
 
     steps:
       - name: executing remote ssh commands using ssh key
@@ -108,14 +112,6 @@ jobs:
             const getStatusEmoji = (s) => s === 'success' ? '✅' : '❌';
             const body = `### 🚀 Client Production Deployment\n- **Status:** ${getStatusEmoji(status)} ${status}\n- **URL:** [https://allcll.kr](https://allcll.kr)\n- **Commit:** ${context.sha.substring(0, 7)}`;
             core.summary.addRaw(body).write();
-            try {
-              await github.rest.repos.createCommitComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                commit_sha: context.sha,
-                body: body
-              });
-            } catch (e) {}
 
 ### Admin page 배포
 
@@ -155,6 +151,9 @@ jobs:
   admin-deploy:
     runs-on: ubuntu-latest
     needs: admin-build
+    environment:
+      name: production-admin
+      url: https://admin.allcll.kr
 
     steps:
       - uses: actions/download-artifact@v4
@@ -191,14 +190,6 @@ jobs:
             const getStatusEmoji = (s) => s === 'success' ? '✅' : '❌';
             const body = `### 🚀 Admin Production Deployment\n- **Status:** ${getStatusEmoji(status)} ${status}\n- **URL:** [https://admin.allcll.kr](https://admin.allcll.kr)\n- **Commit:** ${context.sha.substring(0, 7)}`;
             core.summary.addRaw(body).write();
-            try {
-              await github.rest.repos.createCommitComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                commit_sha: context.sha,
-                body: body
-              });
-            } catch (e) {}
 
 
 # cloudfront 배포

--- a/.github/workflows/dev-build-deploy.yml
+++ b/.github/workflows/dev-build-deploy.yml
@@ -8,6 +8,7 @@ permissions:
   contents: write
   pages: write
   id-token: write
+  deployments: write
 
 # Allow one concurrent deployment
 concurrency:
@@ -64,6 +65,9 @@ jobs:
   client-dev-deploy:
     runs-on: ubuntu-latest
     needs: client-dev-ci
+    environment:
+      name: development
+      url: https://dev.allcll.kr
 
     steps:
       - name: executing remote ssh commands using ssh key
@@ -89,14 +93,6 @@ jobs:
             const getStatusEmoji = (s) => s === 'success' ? '✅' : '❌';
             const body = `### 🛠️ Client Development Deployment\n- **Status:** ${getStatusEmoji(status)} ${status}\n- **URL:** [https://dev.allcll.kr](https://dev.allcll.kr)\n- **Commit:** ${context.sha.substring(0, 7)}`;
             core.summary.addRaw(body).write();
-            try {
-              await github.rest.repos.createCommitComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                commit_sha: context.sha,
-                body: body
-              });
-            } catch (e) {}
 
 
   client-test:
@@ -173,6 +169,9 @@ jobs:
   admin-dev-cd:
     runs-on: ubuntu-latest
     needs: admin-dev-ci
+    environment:
+      name: development-admin
+      url: https://dev-admin.allcll.kr
 
     steps:
       - uses: actions/download-artifact@v4
@@ -209,14 +208,6 @@ jobs:
             const getStatusEmoji = (s) => s === 'success' ? '✅' : '❌';
             const body = `### 🛠️ Admin Development Deployment\n- **Status:** ${getStatusEmoji(status)} ${status}\n- **URL:** [https://dev-admin.allcll.kr](https://dev-admin.allcll.kr)\n- **Commit:** ${context.sha.substring(0, 7)}`;
             core.summary.addRaw(body).write();
-            try {
-              await github.rest.repos.createCommitComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                commit_sha: context.sha,
-                body: body
-              });
-            } catch (e) {}
 
 
 ### Deployment to Cloudfront

--- a/.github/workflows/dev-build-deploy.yml
+++ b/.github/workflows/dev-build-deploy.yml
@@ -8,7 +8,6 @@ permissions:
   contents: write
   pages: write
   id-token: write
-  deployments: write
 
 # Allow one concurrent deployment
 concurrency:
@@ -65,9 +64,6 @@ jobs:
   client-dev-deploy:
     runs-on: ubuntu-latest
     needs: client-dev-ci
-    environment:
-      name: development-client
-      url: https://dev.allcll.kr
 
     steps:
       - name: executing remote ssh commands using ssh key
@@ -177,9 +173,6 @@ jobs:
   admin-dev-cd:
     runs-on: ubuntu-latest
     needs: admin-dev-ci
-    environment:
-      name: development-admin
-      url: https://dev-admin.allcll.kr
 
     steps:
       - uses: actions/download-artifact@v4

--- a/.github/workflows/dev-build-deploy.yml
+++ b/.github/workflows/dev-build-deploy.yml
@@ -8,6 +8,7 @@ permissions:
   contents: write
   pages: write
   id-token: write
+  deployments: write
 
 # Allow one concurrent deployment
 concurrency:
@@ -64,6 +65,9 @@ jobs:
   client-dev-deploy:
     runs-on: ubuntu-latest
     needs: client-dev-ci
+    environment:
+      name: development-client
+      url: https://dev.allcll.kr
 
     steps:
       - name: executing remote ssh commands using ssh key
@@ -79,6 +83,24 @@ jobs:
             sudo git pull https://${{ secrets.GIT_TOKEN }}:x-oauth-basic@github.com/allcll/frontend.git gh-dev-pages
             sudo systemctl reload nginx
             # 필요한 cmd 명령어 사용
+
+      - name: Deployment Report (Client)
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const status = '${{ job.status }}';
+            const getStatusEmoji = (s) => s === 'success' ? '✅' : '❌';
+            const body = `### 🛠️ Client Development Deployment\n- **Status:** ${getStatusEmoji(status)} ${status}\n- **URL:** [https://dev.allcll.kr](https://dev.allcll.kr)\n- **Commit:** ${context.sha.substring(0, 7)}`;
+            core.summary.addRaw(body).write();
+            try {
+              await github.rest.repos.createCommitComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                commit_sha: context.sha,
+                body: body
+              });
+            } catch (e) {}
 
 
   client-test:
@@ -138,7 +160,7 @@ jobs:
           pnpm i --frozen-lockfile
         working-directory: ${{env.working-directory}}
 
-      - name: Build Client project
+      - name: Build Admin project
         run: |
           pnpm run build-admin
           # cd ${{env.project-directory}}
@@ -155,6 +177,9 @@ jobs:
   admin-dev-cd:
     runs-on: ubuntu-latest
     needs: admin-dev-ci
+    environment:
+      name: development-admin
+      url: https://dev-admin.allcll.kr
 
     steps:
       - uses: actions/download-artifact@v4
@@ -181,6 +206,24 @@ jobs:
           port: 22
           script: |
             sudo systemctl reload nginx
+
+      - name: Deployment Report (Admin)
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const status = '${{ job.status }}';
+            const getStatusEmoji = (s) => s === 'success' ? '✅' : '❌';
+            const body = `### 🛠️ Admin Development Deployment\n- **Status:** ${getStatusEmoji(status)} ${status}\n- **URL:** [https://dev-admin.allcll.kr](https://dev-admin.allcll.kr)\n- **Commit:** ${context.sha.substring(0, 7)}`;
+            core.summary.addRaw(body).write();
+            try {
+              await github.rest.repos.createCommitComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                commit_sha: context.sha,
+                body: body
+              });
+            } catch (e) {}
 
 
 ### Deployment to Cloudfront

--- a/.github/workflows/dev-build-deploy.yml
+++ b/.github/workflows/dev-build-deploy.yml
@@ -87,9 +87,11 @@ jobs:
       - name: Deployment Report (Client)
         if: always()
         uses: actions/github-script@v7
+        env:
+          JOB_STATUS: ${{ job.status }}
         with:
           script: |
-            const status = '${{ job.status }}';
+            const status = process.env.JOB_STATUS;
             const getStatusEmoji = (s) => s === 'success' ? '✅' : '❌';
             const body = `### 🛠️ Client Development Deployment\n- **Status:** ${getStatusEmoji(status)} ${status}\n- **URL:** [https://dev.allcll.kr](https://dev.allcll.kr)\n- **Commit:** ${context.sha.substring(0, 7)}`;
             core.summary.addRaw(body).write();
@@ -202,9 +204,11 @@ jobs:
       - name: Deployment Report (Admin)
         if: always()
         uses: actions/github-script@v7
+        env:
+          JOB_STATUS: ${{ job.status }}
         with:
           script: |
-            const status = '${{ job.status }}';
+            const status = process.env.JOB_STATUS;
             const getStatusEmoji = (s) => s === 'success' ? '✅' : '❌';
             const body = `### 🛠️ Admin Development Deployment\n- **Status:** ${getStatusEmoji(status)} ${status}\n- **URL:** [https://dev-admin.allcll.kr](https://dev-admin.allcll.kr)\n- **Commit:** ${context.sha.substring(0, 7)}`;
             core.summary.addRaw(body).write();

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -84,6 +84,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
+      contents: write
     steps:
       - name: Download Client Artifact
         uses: actions/download-artifact@v4
@@ -168,6 +169,42 @@ jobs:
                 body,
               });
             }
+
+      - name: Deployment Report (Preview)
+        if: always()
+        env:
+          CLIENT_PREVIEW_BASE_URL: ${{ secrets.DEV_CLIENT_PREVIEW_BASE_URL }}
+          ADMIN_PREVIEW_BASE_URL: ${{ secrets.DEV_ADMIN_PREVIEW_BASE_URL }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr_number = context.payload.pull_request.number;
+            const client_base_url = process.env.CLIENT_PREVIEW_BASE_URL || 'https://dev.allcll.kr';
+            const admin_base_url = process.env.ADMIN_PREVIEW_BASE_URL || 'https://dev-admin.allcll.kr';
+            const client_preview_url = `${client_base_url}/pr-${pr_number}/`;
+            const admin_preview_url = `${admin_base_url}/pr-${pr_number}/`;
+            
+            const status = '${{ job.status }}';
+            const getStatusEmoji = (s) => s === 'success' ? '✅' : '❌';
+            
+            const body = [
+              '### 🚀 Preview Deployment Report',
+              `- **Status:** ${getStatusEmoji(status)} ${status}`,
+              `- **Client:** [${client_preview_url}](${client_preview_url})`,
+              `- **Admin:** [${admin_preview_url}](${admin_preview_url})`,
+              `- **Commit:** ${context.sha.substring(0, 7)}`
+            ].join('\n');
+            
+            core.summary.addRaw(body).write();
+            
+            try {
+              await github.rest.repos.createCommitComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                commit_sha: context.sha,
+                body: body
+              });
+            } catch (e) {}
 
   cleanup-preview:
     if: github.event.action == 'closed' && github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -84,7 +84,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
-      contents: write
     steps:
       - name: Download Client Artifact
         uses: actions/download-artifact@v4

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -85,6 +85,10 @@ jobs:
     permissions:
       pull-requests: write
       contents: write
+      deployments: write
+    environment:
+      name: preview/pr-${{ github.event.pull_request.number }}
+      url: https://dev.allcll.kr/pr-${{ github.event.pull_request.number }}/
     steps:
       - name: Download Client Artifact
         uses: actions/download-artifact@v4
@@ -196,15 +200,6 @@ jobs:
             ].join('\n');
             
             core.summary.addRaw(body).write();
-            
-            try {
-              await github.rest.repos.createCommitComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                commit_sha: context.sha,
-                body: body
-              });
-            } catch (e) {}
 
   cleanup-preview:
     if: github.event.action == 'closed' && github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -85,10 +85,6 @@ jobs:
     permissions:
       pull-requests: write
       contents: write
-      deployments: write
-    environment:
-      name: preview/pr-${{ github.event.pull_request.number }}
-      url: https://dev.allcll.kr/pr-${{ github.event.pull_request.number }}/
     steps:
       - name: Download Client Artifact
         uses: actions/download-artifact@v4
@@ -173,33 +169,6 @@ jobs:
                 body,
               });
             }
-
-      - name: Deployment Report (Preview)
-        if: always()
-        env:
-          CLIENT_PREVIEW_BASE_URL: ${{ secrets.DEV_CLIENT_PREVIEW_BASE_URL }}
-          ADMIN_PREVIEW_BASE_URL: ${{ secrets.DEV_ADMIN_PREVIEW_BASE_URL }}
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const pr_number = context.payload.pull_request.number;
-            const client_base_url = process.env.CLIENT_PREVIEW_BASE_URL || 'https://dev.allcll.kr';
-            const admin_base_url = process.env.ADMIN_PREVIEW_BASE_URL || 'https://dev-admin.allcll.kr';
-            const client_preview_url = `${client_base_url}/pr-${pr_number}/`;
-            const admin_preview_url = `${admin_base_url}/pr-${pr_number}/`;
-            
-            const status = '${{ job.status }}';
-            const getStatusEmoji = (s) => s === 'success' ? '✅' : '❌';
-            
-            const body = [
-              '### 🚀 Preview Deployment Report',
-              `- **Status:** ${getStatusEmoji(status)} ${status}`,
-              `- **Client:** [${client_preview_url}](${client_preview_url})`,
-              `- **Admin:** [${admin_preview_url}](${admin_preview_url})`,
-              `- **Commit:** ${context.sha.substring(0, 7)}`
-            ].join('\n');
-            
-            core.summary.addRaw(body).write();
 
   cleanup-preview:
     if: github.event.action == 'closed' && github.event.pull_request.head.repo.full_name == github.repository


### PR DESCRIPTION
### 🚀 작업 개요
배포 프로세스의 투명성을 높이고, 개발자와 협업자들이 배포 상태를 GitHub 상에서 쉽고 직관적으로 확인할 수 있도록 CI/CD 워크플로우를 개선했습니다.

---

### 🧐 기존의 문제점 (Why?)
- **배포 상태 확인의 어려움**: 배포가 성공했는지, 현재 서버에 어떤 버전이 올라가 있는지 확인하려면 직접 GitHub Actions 로그를 뒤져보거나 서버에 접속해야 했습니다.
- **가시성 부족**: 인프라 구조를 잘 모르는 팀원들은 현재 운영/개발 서버의 최신 URL이 무엇인지, 배포가 진행 중인지 알기 어려웠습니다.
- **이력 관리 부재**: 과거에 언제, 어떤 코드가 배포되었는지에 대한 공식적인 기록(History)이 GitHub 환경 탭에 남지 않았습니다.

### 🛠 해결 방법 (How?)
1. **GitHub 공식 Deployment 연동**: 
   - environment 설정을 통해 GitHub이 제공하는 공식 배포 관리 기능을 활성화했습니다.
   - 이제 GitHub 레포지토리 메인 우측의 **Environments** 섹션에서 실시간 배포 상태를 볼 수 있습니다.
2. **배포 리포트 자동 생성 (Job Summary)**:
   - 배포가 완료되면 Actions 실행 결과 페이지에 Client와 Admin 서비스의 배포 결과와 접속 URL을 표 형식으로 정리하여 보여줍니다.
3. **불필요한 복잡도 제거**:
   - PR Preview(미리보기)의 경우, 너무 많은 배포 기록이 남으면 오히려 혼란을 줄 수 있어 기존의 편리한 'PR 댓글 안내' 방식만 유지하고 공식 기록은 운영/개발 서버에만 남기도록 최적화했습니다.

### ✨ 변경 후 달라지는 점 (Result!)
- **한눈에 보는 배포 상태**: 이제 레포지토리 첫 화면에서 'production', 'development' 서버가 정상 작동 중인지 바로 확인할 수 있습니다.
- **빠른 서비스 접속**: 배포가 끝나면 일일이 주소를 입력할 필요 없이, GitHub Actions 결과창에서 제공되는 링크를 클릭해 즉시 확인이 가능합니다.
- **투명한 이력 관리**: 누가, 언제, 어떤 기능을 배포했는지에 대한 타임라인이 GitHub에 영구적으로 기록되어 장애 복구나 버전 관리가 훨씬 수월해집니다.

#### 이렇게 바뀌어요
allcll-frontend Repository 메인화면 우측에 아래와 같은 링크가 자동으로 생깁니다!
<img width="306" height="142" alt="image" src="https://github.com/user-attachments/assets/a9b20987-7af2-4f95-9c25-2801841af37b" />


---

### 📝 주요 변경 파일
- .github/workflows/build-deploy.yml: 운영 환경 배포 리포트 및 Deployment 연동
- .github/workflows/dev-build-deploy.yml: 개발 환경 배포 리포트 및 Deployment 연동
- .github/workflows/pr-ci.yml: PR 미리보기 워크플로우 최적화