### PR TITLE
refactor: 시간표 오류 및 사용자 피드백 처리

### DIFF
--- a/packages/allcll-ui/index.ts
+++ b/packages/allcll-ui/index.ts
@@ -8,7 +8,7 @@ export { Dialog } from './src/components/dialog/Dialog';
 export { default as IconButton } from './src/components/icon-button/IconButton';
 export { default as Input } from './src/components/input/Input';
 export { default as Label } from './src/components/label/Label';
-export { Popover } from './src/components/popover/popover/Popover';
+export { Popover, usePopoverContext } from './src/components/popover/popover/Popover';
 export { default as RowCenter } from './src/components/row/RowCenter';
 export { default as RowLeft } from './src/components/row/RowLeft';
 export { default as RowMain } from './src/components/row/RowMain';

--- a/packages/allcll-ui/src/components/dialog/Dialog.tsx
+++ b/packages/allcll-ui/src/components/dialog/Dialog.tsx
@@ -23,7 +23,7 @@ function DialogMain({ children, isOpen = true, title, onClose }: IDialogMain) {
     if (!dialog) return;
 
     if (isOpen) {
-      dialog.showModal();
+      dialog.show();
     } else {
       dialog.close();
     }
@@ -43,6 +43,7 @@ function DialogMain({ children, isOpen = true, title, onClose }: IDialogMain) {
       ref={dialogRef}
       role="dialog"
       aria-labelledby={titleId}
+      className="border-0 p-0 bg-transparent max-w-none max-h-none overflow-visible"
       onCancel={e => {
         e.preventDefault();
         onClose();

--- a/packages/allcll-ui/src/components/dialog/Dialog.tsx
+++ b/packages/allcll-ui/src/components/dialog/Dialog.tsx
@@ -43,7 +43,6 @@ function DialogMain({ children, isOpen = true, title, onClose }: IDialogMain) {
       ref={dialogRef}
       role="dialog"
       aria-labelledby={titleId}
-      className="border-0 p-0 bg-transparent max-w-none max-h-none overflow-visible"
       onCancel={e => {
         e.preventDefault();
         onClose();

--- a/packages/allcll-ui/src/components/dialog/Dialog.tsx
+++ b/packages/allcll-ui/src/components/dialog/Dialog.tsx
@@ -23,7 +23,7 @@ function DialogMain({ children, isOpen = true, title, onClose }: IDialogMain) {
     if (!dialog) return;
 
     if (isOpen) {
-      dialog.show();
+      dialog.showModal();
     } else {
       dialog.close();
     }

--- a/packages/allcll-ui/src/components/dialog/DialogOverlay.tsx
+++ b/packages/allcll-ui/src/components/dialog/DialogOverlay.tsx
@@ -15,7 +15,7 @@ function DialogOverlay({ children, onClose }: IDialogOverlay) {
 
   return (
     <div
-      className="fixed inset-0 flex items-center bg-black/40 justify-center z-50"
+      className="fixed inset-0 flex items-center bg-black/40 justify-center z-300"
       role="none"
       ref={containerRef}
       onClick={handleBackdropClick}

--- a/packages/allcll-ui/src/components/dialog/DialogOverlay.tsx
+++ b/packages/allcll-ui/src/components/dialog/DialogOverlay.tsx
@@ -15,7 +15,7 @@ function DialogOverlay({ children, onClose }: IDialogOverlay) {
 
   return (
     <div
-      className="fixed inset-0 flex items-center bg-black/40 justify-center z-300"
+      className="fixed inset-0 flex items-center bg-transparent justify-center z-300"
       role="none"
       ref={containerRef}
       onClick={handleBackdropClick}

--- a/packages/allcll-ui/src/components/dialog/DialogOverlay.tsx
+++ b/packages/allcll-ui/src/components/dialog/DialogOverlay.tsx
@@ -15,7 +15,7 @@ function DialogOverlay({ children, onClose }: IDialogOverlay) {
 
   return (
     <div
-      className="fixed inset-0 flex items-center bg-transparent justify-center z-50"
+      className="fixed inset-0 flex items-center bg-black/40 justify-center z-50"
       role="none"
       ref={containerRef}
       onClick={handleBackdropClick}

--- a/packages/client/src/app/index.css
+++ b/packages/client/src/app/index.css
@@ -4,8 +4,9 @@
 @layer base {
   @font-face {
     font-family: 'Pretendard';
-    src: url('/font/woff2/Pretendard-Regular.subset.woff2') format('woff2'),
-        url('/font/woff/Pretendard-Regular.subset.woff') format('woff');
+    src:
+      url('/font/woff2/Pretendard-Regular.subset.woff2') format('woff2'),
+      url('/font/woff/Pretendard-Regular.subset.woff') format('woff');
 
     font-weight: 400;
     font-style: normal;
@@ -14,8 +15,9 @@
 
   @font-face {
     font-family: 'Pretendard';
-    src: url('/font/woff2/Pretendard-SemiBold.subset.woff2') format('woff2'),
-        url('/font/woff/Pretendard-SemiBold.subset.woff') format('woff');
+    src:
+      url('/font/woff2/Pretendard-SemiBold.subset.woff2') format('woff2'),
+      url('/font/woff/Pretendard-SemiBold.subset.woff') format('woff');
 
     font-weight: 600;
     font-style: normal;
@@ -24,8 +26,9 @@
 
   @font-face {
     font-family: 'Pretendard';
-    src: url('/font/woff2/Pretendard-Bold.subset.woff2') format('woff2'),
-        url('/font/woff/Pretendard-Bold.subset.woff') format('woff');
+    src:
+      url('/font/woff2/Pretendard-Bold.subset.woff2') format('woff2'),
+      url('/font/woff/Pretendard-Bold.subset.woff') format('woff');
 
     font-weight: 700;
     font-style: normal;
@@ -118,6 +121,20 @@ body {
 .toast-move {
   transform: translateY(100%);
   transition: transform 300ms;
+}
+.toast-popover-root {
+  border: 0;
+  padding: 0;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  pointer-events: none;
+}
+.toast-popover-root::backdrop {
+  display: none;
+}
+.toast-popover-root button {
+  pointer-events: auto;
 }
 
 .seat-change-enter {

--- a/packages/client/src/entities/timetable/api/useTimetableSchedules.ts
+++ b/packages/client/src/entities/timetable/api/useTimetableSchedules.ts
@@ -84,7 +84,7 @@ export interface InitTimetableType {
   semesterCode: string;
 }
 
-interface TimetableMutationOptions {
+interface ITimetableMutationOptions {
   onSuccess?: () => void;
 }
 
@@ -152,7 +152,7 @@ export function useGetTimetableSchedules(timetableId?: number, semester?: string
  * 시간표 수정 훅
  * timetableId에에 대한 timetableName을 수정합니다.
  */
-export function useUpdateTimetable(options?: TimetableMutationOptions) {
+export function useUpdateTimetable(options?: ITimetableMutationOptions) {
   const queryClient = useQueryClient();
   const { currentTimetable, pickTimetable } = useScheduleState.getState();
 
@@ -197,7 +197,7 @@ export function useUpdateTimetable(options?: TimetableMutationOptions) {
  * 시간표 삭제 훅
  * timetableId로 시간표를 삭제합니다.
  */
-export function useDeleteTimetable(options?: TimetableMutationOptions) {
+export function useDeleteTimetable(options?: ITimetableMutationOptions) {
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -234,7 +234,7 @@ export function useDeleteTimetable(options?: TimetableMutationOptions) {
  * 시간표 생성 훅
  * 시간표를 생성합니다.
  */
-export function useCreateTimetable(options?: TimetableMutationOptions) {
+export function useCreateTimetable(options?: ITimetableMutationOptions) {
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -276,7 +276,7 @@ interface ScheduleMutationProps {
   schedule: ScheduleApiResponse;
 }
 
-interface ScheduleMutationOptions {
+interface IScheduleMutationOptions {
   onSuccess?: () => void;
 }
 
@@ -287,7 +287,7 @@ interface ScheduleMutationOptions {
  * @param timetableId
  * @param semesterCode
  */
-export function useCreateSchedule(timetableId?: number, semesterCode?: string, options?: ScheduleMutationOptions) {
+export function useCreateSchedule(timetableId?: number, semesterCode?: string, options?: IScheduleMutationOptions) {
   semesterCode = semesterCode ?? RECENT_SEMESTERS.semesterCode;
 
   const queryClient = useQueryClient();
@@ -306,8 +306,8 @@ export function useCreateSchedule(timetableId?: number, semesterCode?: string, o
         targetTimetableId = timetable.timeTableId;
 
         /* timetable 생성 후, transaction을 위해 잠시 대기
-        -> targetTimetableId로 스케줄을 생성하기 위해
-        */
+                -> targetTimetableId로 스케줄을 생성하기 위해
+                */
         await timeSleep(300);
 
         // 시간표 생성 후, optimistic하게 스케줄을 설정합니다.
@@ -376,7 +376,7 @@ export function useCreateSchedule(timetableId?: number, semesterCode?: string, o
  * onSuccess: 성공 시 캐싱된 데이터를 업데이트합니다.
  * @param timetableId
  */
-export function useUpdateSchedule(timetableId?: number, options?: ScheduleMutationOptions) {
+export function useUpdateSchedule(timetableId?: number, options?: IScheduleMutationOptions) {
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -426,7 +426,7 @@ export function useUpdateSchedule(timetableId?: number, options?: ScheduleMutati
  * onSuccess: 성공 시 캐싱된 데이터를 업데이트합니다.
  * @param timetableId
  */
-export function useDeleteSchedule(timetableId?: number, options?: ScheduleMutationOptions) {
+export function useDeleteSchedule(timetableId?: number, options?: IScheduleMutationOptions) {
   const queryClient = useQueryClient();
 
   return useMutation({

--- a/packages/client/src/entities/timetable/api/useTimetableSchedules.ts
+++ b/packages/client/src/entities/timetable/api/useTimetableSchedules.ts
@@ -197,7 +197,13 @@ export function useDeleteTimetable() {
 
   return useMutation({
     mutationFn: async (timeTableId: number) => {
-      return await fetchOnAPI(`/api/timetables/${timeTableId}`, { method: 'DELETE' });
+      const response = await fetchOnAPI(`/api/timetables/${timeTableId}`, { method: 'DELETE' });
+
+      if (!response.ok) {
+        throw new Error(await response.text());
+      }
+
+      return response;
     },
     onMutate: async (timeTableId: number) => {
       await queryClient.cancelQueries({ queryKey: ['timetableList'] });

--- a/packages/client/src/entities/timetable/api/useTimetableSchedules.ts
+++ b/packages/client/src/entities/timetable/api/useTimetableSchedules.ts
@@ -84,6 +84,10 @@ export interface InitTimetableType {
   semesterCode: string;
 }
 
+interface TimetableMutationOptions {
+  onSuccess?: () => void;
+}
+
 const InitTimetableSchedules = {
   timeTableId: -1,
   timeTableName: '새 시간표',
@@ -148,7 +152,7 @@ export function useGetTimetableSchedules(timetableId?: number, semester?: string
  * 시간표 수정 훅
  * timetableId에에 대한 timetableName을 수정합니다.
  */
-export function useUpdateTimetable() {
+export function useUpdateTimetable(options?: TimetableMutationOptions) {
   const queryClient = useQueryClient();
   const { currentTimetable, pickTimetable } = useScheduleState.getState();
 
@@ -178,6 +182,7 @@ export function useUpdateTimetable() {
 
       await queryClient.invalidateQueries({ queryKey: ['timetableList'] });
       await queryClient.invalidateQueries({ queryKey: ['timetableList', updatedId] });
+      options?.onSuccess?.();
     },
 
     onError: async (error, _variables, context) => {
@@ -192,7 +197,7 @@ export function useUpdateTimetable() {
  * 시간표 삭제 훅
  * timetableId로 시간표를 삭제합니다.
  */
-export function useDeleteTimetable() {
+export function useDeleteTimetable(options?: TimetableMutationOptions) {
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -220,6 +225,7 @@ export function useDeleteTimetable() {
       await queryClient.invalidateQueries({
         queryKey: ['timetableData', context?.timeTableId],
       });
+      options?.onSuccess?.();
     },
   });
 }
@@ -228,7 +234,7 @@ export function useDeleteTimetable() {
  * 시간표 생성 훅
  * 시간표를 생성합니다.
  */
-export function useCreateTimetable() {
+export function useCreateTimetable(options?: TimetableMutationOptions) {
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -257,6 +263,7 @@ export function useCreateTimetable() {
       });
 
       await queryClient.invalidateQueries({ queryKey: ['timetableList'] });
+      options?.onSuccess?.();
     },
     onError: async error => {
       console.error('시간표 생성 실패:', error);
@@ -269,6 +276,10 @@ interface ScheduleMutationProps {
   schedule: ScheduleApiResponse;
 }
 
+interface ScheduleMutationOptions {
+  onSuccess?: () => void;
+}
+
 /** 스케줄을 생성하는 Mutation 훅입니다.
  * onMutate: mutation 전에 캐싱된 데이터를 context로 넘겨줍니다.
  * onError: 에러 발생 시 캐싱된 데이터를 롤백합니다.
@@ -276,7 +287,7 @@ interface ScheduleMutationProps {
  * @param timetableId
  * @param semesterCode
  */
-export function useCreateSchedule(timetableId?: number, semesterCode?: string) {
+export function useCreateSchedule(timetableId?: number, semesterCode?: string, options?: ScheduleMutationOptions) {
   semesterCode = semesterCode ?? RECENT_SEMESTERS.semesterCode;
 
   const queryClient = useQueryClient();
@@ -353,6 +364,8 @@ export function useCreateSchedule(timetableId?: number, semesterCode?: string) {
           return sch; // Return unchanged schedules
         }),
       });
+
+      options?.onSuccess?.();
     },
   });
 }
@@ -363,7 +376,7 @@ export function useCreateSchedule(timetableId?: number, semesterCode?: string) {
  * onSuccess: 성공 시 캐싱된 데이터를 업데이트합니다.
  * @param timetableId
  */
-export function useUpdateSchedule(timetableId?: number) {
+export function useUpdateSchedule(timetableId?: number, options?: ScheduleMutationOptions) {
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -388,6 +401,7 @@ export function useUpdateSchedule(timetableId?: number) {
       if (!context?.prevTimetableSchedules) {
         await queryClient.invalidateQueries({ queryKey: ['timetableList'] });
         await queryClient.invalidateQueries({ queryKey: ['timetableData', timetableId] });
+        options?.onSuccess?.();
         return;
       }
 
@@ -400,6 +414,8 @@ export function useUpdateSchedule(timetableId?: number) {
           return sch; // Return unchanged schedules
         }),
       });
+
+      options?.onSuccess?.();
     },
   });
 }
@@ -410,7 +426,7 @@ export function useUpdateSchedule(timetableId?: number) {
  * onSuccess: 성공 시 캐싱된 데이터를 업데이트합니다.
  * @param timetableId
  */
-export function useDeleteSchedule(timetableId?: number) {
+export function useDeleteSchedule(timetableId?: number, options?: ScheduleMutationOptions) {
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -436,6 +452,7 @@ export function useDeleteSchedule(timetableId?: number) {
       if (!context?.prevTimetableSchedules) {
         await queryClient.invalidateQueries({ queryKey: ['timetableList'] });
         await queryClient.invalidateQueries({ queryKey: ['timetableData', timetableId] });
+        options?.onSuccess?.();
         return;
       }
 
@@ -446,6 +463,7 @@ export function useDeleteSchedule(timetableId?: number) {
       });
 
       await queryClient.invalidateQueries({ queryKey: ['timetableData', timetableId] });
+      options?.onSuccess?.();
     },
   });
 }

--- a/packages/client/src/entities/timetable/api/useTimetableSchedules.ts
+++ b/packages/client/src/entities/timetable/api/useTimetableSchedules.ts
@@ -253,12 +253,7 @@ export function useCreateTimetable() {
       await queryClient.invalidateQueries({ queryKey: ['timetableList'] });
     },
     onError: async error => {
-      try {
-        const e = JSON.parse(error.message);
-        alert(e.message);
-      } catch {
-        alert('Error adding Timetable');
-      }
+      console.error('시간표 생성 실패:', error);
       await queryClient.invalidateQueries({ queryKey: ['timetableList'] });
     },
   });
@@ -466,7 +461,7 @@ function toGeneralSchedules(timetable: Timetable, subjects?: Subject[]): General
  * @param generalSchedules - Schedule 배열
  * @param minTime
  */
-export function getScheduleSlots(generalSchedules?: GeneralSchedule[], minTime = 9) {
+export function useScheduleSlots(generalSchedules?: GeneralSchedule[], minTime = 9) {
   const selectedSchedule = useScheduleState(state => state.schedule);
   const selectMode = useScheduleState(state => state.mode);
   const colors: ScheduleSlot['color'][] = ['rose', 'amber', 'green', 'emerald', 'blue', 'violet'];
@@ -575,7 +570,7 @@ export interface EmptyScheduleSlot extends GeneralSchedule {
 /** 시간표의 Timeslot이 비어있는 ScheduleSlot 을 가져오는 훅입니다.
  * @param generalSchedules - Schedule 배열
  */
-export function getEmptyScheduleSlots(generalSchedules?: GeneralSchedule[]): EmptyScheduleSlot[] {
+export function useEmptyScheduleSlots(generalSchedules?: GeneralSchedule[]): EmptyScheduleSlot[] {
   const schedule = useScheduleState(state => state.schedule);
   const mode = useScheduleState(state => state.mode);
 

--- a/packages/client/src/features/notification/model/useToastNotification.ts
+++ b/packages/client/src/features/notification/model/useToastNotification.ts
@@ -14,7 +14,6 @@ interface IUseToastNotification {
 }
 
 let toastId = 0;
-const toastTimers = new Map<string, ReturnType<typeof setTimeout>>();
 
 const useToastNotification = create<IUseToastNotification>((set, get) => ({
   isActivated: false,
@@ -24,13 +23,9 @@ const useToastNotification = create<IUseToastNotification>((set, get) => ({
 
     set(state => ({ messages: [...state.messages, toast] }));
     if (tag) {
-      const timerKey = `${tag}-${toast.id}`;
-      const timer = setTimeout(() => {
+      setTimeout(() => {
         get().clearToast(toast.id);
-        toastTimers.delete(timerKey);
       }, 3000);
-
-      toastTimers.set(timerKey, timer);
     }
   },
   clearToast: filter =>

--- a/packages/client/src/features/notification/model/useToastNotification.ts
+++ b/packages/client/src/features/notification/model/useToastNotification.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
 
 export interface IToastMessage {
+  id: number;
   message: string;
   tag?: string;
 }
@@ -12,19 +13,30 @@ interface IUseToastNotification {
   clearToast: (filter: number | string) => void;
 }
 
+let toastId = 0;
+const toastTimers = new Map<string, ReturnType<typeof setTimeout>>();
+
 const useToastNotification = create<IUseToastNotification>((set, get) => ({
   isActivated: false,
   messages: [],
   addToast: (message, tag) => {
-    set(state => ({ messages: [...state.messages, { message, tag }] }));
+    const toast = { id: toastId++, message, tag };
+
+    set(state => ({ messages: [...state.messages, toast] }));
     if (tag) {
-      setTimeout(() => get().clearToast(tag), 3000);
+      const timerKey = `${tag}-${toast.id}`;
+      const timer = setTimeout(() => {
+        get().clearToast(toast.id);
+        toastTimers.delete(timerKey);
+      }, 3000);
+
+      toastTimers.set(timerKey, timer);
     }
   },
   clearToast: filter =>
     set(state => {
       if (typeof filter === 'number') {
-        state.messages = [...state.messages.slice(0, filter), ...state.messages.slice(filter + 1)];
+        state.messages = state.messages.filter(m => m.id !== filter);
       } else {
         state.messages = state.messages.filter(m => m.tag !== filter);
       }

--- a/packages/client/src/features/notification/ui/ToastNotification.tsx
+++ b/packages/client/src/features/notification/ui/ToastNotification.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from 'react';
 import { CSSTransition, TransitionGroup } from 'react-transition-group';
 import { createPortal } from 'react-dom';
 import CloseSvg from '@/assets/x-gray.svg?react';
@@ -7,19 +8,29 @@ import useToastNotification, { IToastMessage } from '../model/useToastNotificati
 function ToastNotification() {
   const messages = useToastNotification(state => state.messages);
   const closeToast = useToastNotification(state => state.clearToast);
-  const portalTarget = getToastPortalTarget();
+  const popoverRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const popover = popoverRef.current;
+
+    if (popover && 'showPopover' in popover && !popover.matches(':popover-open')) {
+      popover.showPopover();
+    }
+  }, []);
 
   return createPortal(
-    <div className="fixed top-2 right-2 z-400 max-w-screen">
-      <TransitionGroup className="flex gap-2 flex-col-reverse">
-        {messages.slice(-3).map(message => (
-          <CSSTransition key={message.id} timeout={300} classNames="toast">
-            <Toast toast={message} closeToast={() => closeToast(message.id)} />
-          </CSSTransition>
-        ))}
-      </TransitionGroup>
+    <div ref={popoverRef} popover="manual" className="toast-popover-root">
+      <div className="fixed top-2 right-2 z-400 max-w-screen">
+        <TransitionGroup className="flex gap-2 flex-col-reverse">
+          {messages.slice(-3).map(message => (
+            <CSSTransition key={message.id} timeout={300} classNames="toast">
+              <Toast toast={message} closeToast={() => closeToast(message.id)} />
+            </CSSTransition>
+          ))}
+        </TransitionGroup>
+      </div>
     </div>,
-    portalTarget,
+    document.body,
   );
 }
 
@@ -41,32 +52,3 @@ function Toast({ toast, closeToast }: IToast) {
 }
 
 export default ToastNotification;
-
-function getToastPortalTarget() {
-  const popoverRoot = getToastPopoverRoot();
-
-  if (popoverRoot) {
-    return popoverRoot;
-  }
-
-  return document.body;
-}
-
-function getToastPopoverRoot() {
-  const id = 'toast-popover-root';
-  let root = document.getElementById(id);
-
-  if (!root) {
-    root = document.createElement('div');
-    root.id = id;
-    root.setAttribute('popover', 'manual');
-    root.className = 'toast-popover-root';
-    document.body.appendChild(root);
-  }
-
-  if ('showPopover' in root && !root.matches(':popover-open')) {
-    root.showPopover();
-  }
-
-  return root;
-}

--- a/packages/client/src/features/notification/ui/ToastNotification.tsx
+++ b/packages/client/src/features/notification/ui/ToastNotification.tsx
@@ -12,9 +12,9 @@ function ToastNotification() {
   return createPortal(
     <div className="fixed top-2 right-2 z-400 max-w-screen">
       <TransitionGroup className="flex gap-2 flex-col-reverse">
-        {messages.slice(-3).map((message, index) => (
-          <CSSTransition key={`${index} : ${message}`} timeout={300} classNames="toast">
-            <Toast toast={message} closeToast={() => closeToast(index)} />
+        {messages.slice(-3).map(message => (
+          <CSSTransition key={message.id} timeout={300} classNames="toast">
+            <Toast toast={message} closeToast={() => closeToast(message.id)} />
           </CSSTransition>
         ))}
       </TransitionGroup>
@@ -43,6 +43,30 @@ function Toast({ toast, closeToast }: IToast) {
 export default ToastNotification;
 
 function getToastPortalTarget() {
-  const openedDialogs = document.querySelectorAll<HTMLDialogElement>('dialog[open]');
-  return openedDialogs[openedDialogs.length - 1] ?? document.body;
+  const popoverRoot = getToastPopoverRoot();
+
+  if (popoverRoot) {
+    return popoverRoot;
+  }
+
+  return document.body;
+}
+
+function getToastPopoverRoot() {
+  const id = 'toast-popover-root';
+  let root = document.getElementById(id);
+
+  if (!root) {
+    root = document.createElement('div');
+    root.id = id;
+    root.setAttribute('popover', 'manual');
+    root.className = 'toast-popover-root';
+    document.body.appendChild(root);
+  }
+
+  if ('showPopover' in root && !root.matches(':popover-open')) {
+    root.showPopover();
+  }
+
+  return root;
 }

--- a/packages/client/src/features/notification/ui/ToastNotification.tsx
+++ b/packages/client/src/features/notification/ui/ToastNotification.tsx
@@ -8,7 +8,7 @@ function ToastNotification() {
   const closeToast = useToastNotification(state => state.clearToast);
 
   return (
-    <div className="fixed top-2 right-2 z-100 max-w-screen">
+    <div className="fixed top-2 right-2 z-400 max-w-screen">
       <TransitionGroup className="flex gap-2 flex-col-reverse">
         {messages.slice(-3).map((message, index) => (
           <CSSTransition key={`${index} : ${message}`} timeout={300} classNames="toast">

--- a/packages/client/src/features/notification/ui/ToastNotification.tsx
+++ b/packages/client/src/features/notification/ui/ToastNotification.tsx
@@ -1,4 +1,5 @@
 import { CSSTransition, TransitionGroup } from 'react-transition-group';
+import { createPortal } from 'react-dom';
 import CloseSvg from '@/assets/x-gray.svg?react';
 import AlarmSvg from '@/assets/alarm.svg?react';
 import useToastNotification, { IToastMessage } from '../model/useToastNotification';
@@ -6,8 +7,9 @@ import useToastNotification, { IToastMessage } from '../model/useToastNotificati
 function ToastNotification() {
   const messages = useToastNotification(state => state.messages);
   const closeToast = useToastNotification(state => state.clearToast);
+  const portalTarget = getToastPortalTarget();
 
-  return (
+  return createPortal(
     <div className="fixed top-2 right-2 z-400 max-w-screen">
       <TransitionGroup className="flex gap-2 flex-col-reverse">
         {messages.slice(-3).map((message, index) => (
@@ -16,7 +18,8 @@ function ToastNotification() {
           </CSSTransition>
         ))}
       </TransitionGroup>
-    </div>
+    </div>,
+    portalTarget,
   );
 }
 
@@ -38,3 +41,8 @@ function Toast({ toast, closeToast }: IToast) {
 }
 
 export default ToastNotification;
+
+function getToastPortalTarget() {
+  const openedDialogs = document.querySelectorAll<HTMLDialogElement>('dialog[open]');
+  return openedDialogs[openedDialogs.length - 1] ?? document.body;
+}

--- a/packages/client/src/features/timetable/lib/showTimetableApiErrorToast.ts
+++ b/packages/client/src/features/timetable/lib/showTimetableApiErrorToast.ts
@@ -20,7 +20,7 @@ export function showTimetableApiErrorToast(error: unknown, options: ShowTimetabl
 
 function getTimetableApiErrorMessage(error: unknown) {
   if (error instanceof TypeError) {
-    return '인터넷 연결을 확인해주세요. 네트워크 상태를 확인 후 다시 시도해주세요.';
+    return '네트워크 상태를 확인 후 다시 시도해주세요.';
   }
 
   if (!(error instanceof Error)) return null;

--- a/packages/client/src/features/timetable/lib/showTimetableApiErrorToast.ts
+++ b/packages/client/src/features/timetable/lib/showTimetableApiErrorToast.ts
@@ -11,9 +11,20 @@ interface ShowTimetableApiErrorToastOptions {
   tag: string;
 }
 
+interface ShowTimetableApiSuccessToastOptions {
+  message: string;
+  tag: string;
+}
+
 export function showTimetableApiErrorToast(error: unknown, options: ShowTimetableApiErrorToastOptions) {
   const { fallbackMessage, tag } = options;
   const message = getTimetableApiErrorMessage(error) ?? fallbackMessage;
+
+  useToastNotification.getState().addToast(message, tag);
+}
+
+export function showTimetableApiSuccessToast(options: ShowTimetableApiSuccessToastOptions) {
+  const { message, tag } = options;
 
   useToastNotification.getState().addToast(message, tag);
 }

--- a/packages/client/src/features/timetable/lib/showTimetableApiErrorToast.ts
+++ b/packages/client/src/features/timetable/lib/showTimetableApiErrorToast.ts
@@ -1,0 +1,44 @@
+import useToastNotification from '@/features/notification/model/useToastNotification.ts';
+
+interface TimetableApiErrorResponse {
+  success?: boolean;
+  message?: string;
+  errorCode?: string;
+}
+
+interface ShowTimetableApiErrorToastOptions {
+  fallbackMessage: string;
+  tag: string;
+}
+
+export function showTimetableApiErrorToast(error: unknown, options: ShowTimetableApiErrorToastOptions) {
+  const { fallbackMessage, tag } = options;
+  const message = getTimetableApiErrorMessage(error) ?? fallbackMessage;
+
+  useToastNotification.getState().addToast(message, tag);
+}
+
+function getTimetableApiErrorMessage(error: unknown) {
+  if (error instanceof TypeError) {
+    return '인터넷 연결을 확인해주세요. 네트워크 상태를 확인 후 다시 시도해주세요.';
+  }
+
+  if (!(error instanceof Error)) return null;
+
+  const parsed = parseApiErrorResponse(error.message);
+  return parsed?.message ?? null;
+}
+
+function parseApiErrorResponse(message: string): TimetableApiErrorResponse | null {
+  try {
+    const parsed = JSON.parse(message) as TimetableApiErrorResponse;
+
+    if (typeof parsed.message === 'string' && parsed.message.length > 0) {
+      return parsed;
+    }
+
+    return null;
+  } catch {
+    return null;
+  }
+}

--- a/packages/client/src/features/timetable/lib/useDeleteConfirmation.ts
+++ b/packages/client/src/features/timetable/lib/useDeleteConfirmation.ts
@@ -1,0 +1,25 @@
+import { useState, type MouseEvent } from 'react';
+
+function useDeleteConfirmation(onConfirm: () => void) {
+  const [isDeleteConfirming, setIsDeleteConfirming] = useState(false);
+
+  const requestDeleteConfirmation = (e?: MouseEvent<HTMLButtonElement>) => {
+    e?.preventDefault();
+    setIsDeleteConfirming(true);
+  };
+
+  const cancelDeleteConfirmation = (e: MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setIsDeleteConfirming(false);
+  };
+
+  return {
+    isDeleteConfirming,
+    requestDeleteConfirmation,
+    cancelDeleteConfirmation,
+    confirmDelete: onConfirm,
+  };
+}
+
+export default useDeleteConfirmation;

--- a/packages/client/src/features/timetable/lib/useScheduleModal.ts
+++ b/packages/client/src/features/timetable/lib/useScheduleModal.ts
@@ -15,7 +15,7 @@ import { ScheduleMutateType, useScheduleState } from '@/features/timetable/model
 import { useBottomSheetStore } from '@/shared/model/useBottomSheetStore.ts';
 import { ScheduleAdapter, TimeslotAdapter } from '@/entities/timetable/model/adapter.ts';
 import { useSemesterParam } from '@/entities/semester/model/useSemesterParam';
-import { showTimetableApiErrorToast } from './showTimetableApiErrorToast';
+import { showTimetableApiErrorToast, showTimetableApiSuccessToast } from './showTimetableApiErrorToast';
 
 const getInitCustomSchedule = () => new ScheduleAdapter().toUiData();
 let globalPrevTimetable: Timetable | undefined = undefined;
@@ -33,9 +33,27 @@ function useScheduleModal() {
   const closeBottomSheet = useBottomSheetStore(state => state.closeBottomSheet);
   const [, startTransition] = useTransition();
 
-  const { mutate: createScheduleData } = useCreateSchedule(timetableId, currentSemester);
-  const { mutate: updateScheduleData } = useUpdateSchedule(timetableId);
-  const { mutate: deleteScheduleData } = useDeleteSchedule(timetableId);
+  const { mutate: createScheduleData } = useCreateSchedule(timetableId, currentSemester, {
+    onSuccess: () =>
+      showTimetableApiSuccessToast({
+        message: '과목을 추가했습니다.',
+        tag: 'schedule-create-success',
+      }),
+  });
+  const { mutate: updateScheduleData } = useUpdateSchedule(timetableId, {
+    onSuccess: () =>
+      showTimetableApiSuccessToast({
+        message: '과목을 수정했습니다.',
+        tag: 'schedule-update-success',
+      }),
+  });
+  const { mutate: deleteScheduleData } = useDeleteSchedule(timetableId, {
+    onSuccess: () =>
+      showTimetableApiSuccessToast({
+        message: '과목을 삭제했습니다.',
+        tag: 'schedule-delete-success',
+      }),
+  });
 
   /** Schedule Time 만 제어할 때 사용. 모달을 열고 싶지 않을 때 사용*/
   const setOptimisticSchedule = (targetSchedule: GeneralSchedule) => {

--- a/packages/client/src/features/timetable/lib/useScheduleModal.ts
+++ b/packages/client/src/features/timetable/lib/useScheduleModal.ts
@@ -1,6 +1,7 @@
 // This hook is used to manage the schedule modal state and actions
 import React, { useTransition } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
+import useToastNotification from '@/features/notification/model/useToastNotification.ts';
 import {
   CustomSchedule,
   OfficialSchedule,
@@ -67,7 +68,7 @@ function useScheduleModal() {
     const prevSchedule = useScheduleState.getState().schedule;
     // state 변경 로직
 
-    let newSchedule = schedule instanceof Function ? schedule(prevSchedule) : schedule;
+    const newSchedule = schedule instanceof Function ? schedule(prevSchedule) : schedule;
     changeScheduleData(newSchedule);
   };
 
@@ -89,14 +90,14 @@ function useScheduleModal() {
     const isTimeslotValid = new TimeslotAdapter(prevSchedule.timeSlots).validate();
 
     if (!isTimeslotValid) {
-      alert('시작 시간이 종료 시간 보다 늦지 않아야 합니다.');
+      useToastNotification.getState().addToast('시작 시간이 종료 시간보다 늦지 않아야 합니다.', 'timeslot-validation');
       return;
     }
 
     const isSelectedDay = prevSchedule.timeSlots.length !== 0;
     const isCustom = prevSchedule.scheduleType === 'custom';
     if (isCustom && !isSelectedDay) {
-      alert('요일을 선택해주세요!.');
+      useToastNotification.getState().addToast('요일을 선택해주세요.', 'day-validation');
       return;
     }
 
@@ -106,9 +107,25 @@ function useScheduleModal() {
     if (mode === ScheduleMutateType.CREATE) {
       // 생성중인 Schedule 구분 용 - unique negative id 생성
       schedule.scheduleId = getUniqueNegativeId(globalPrevTimetable?.schedules ?? []);
-      createScheduleData({ schedule });
+      createScheduleData(
+        { schedule },
+        {
+          onError: () =>
+            useToastNotification
+              .getState()
+              .addToast('수업 추가에 실패했습니다. 다시 시도해주세요.', 'schedule-create-error'),
+        },
+      );
     } else if (mode === ScheduleMutateType.EDIT) {
-      updateScheduleData({ schedule });
+      updateScheduleData(
+        { schedule },
+        {
+          onError: () =>
+            useToastNotification
+              .getState()
+              .addToast('수업 수정에 실패했습니다. 다시 시도해주세요.', 'schedule-update-error'),
+        },
+      );
       changeScheduleData({ ...getInitCustomSchedule() }, ScheduleMutateType.NONE);
     }
 
@@ -122,7 +139,15 @@ function useScheduleModal() {
     if (e) e.preventDefault();
 
     const schedule = new ScheduleAdapter(prevSchedule).toApiData();
-    deleteScheduleData({ schedule });
+    deleteScheduleData(
+      { schedule },
+      {
+        onError: () =>
+          useToastNotification
+            .getState()
+            .addToast('수업 삭제에 실패했습니다. 다시 시도해주세요.', 'schedule-delete-error'),
+      },
+    );
 
     // 모달 state 초기화
     changeScheduleData({ ...getInitCustomSchedule() }, ScheduleMutateType.NONE);

--- a/packages/client/src/features/timetable/lib/useScheduleModal.ts
+++ b/packages/client/src/features/timetable/lib/useScheduleModal.ts
@@ -15,6 +15,7 @@ import { ScheduleMutateType, useScheduleState } from '@/features/timetable/model
 import { useBottomSheetStore } from '@/shared/model/useBottomSheetStore.ts';
 import { ScheduleAdapter, TimeslotAdapter } from '@/entities/timetable/model/adapter.ts';
 import { useSemesterParam } from '@/entities/semester/model/useSemesterParam';
+import { showTimetableApiErrorToast } from './showTimetableApiErrorToast';
 
 const getInitCustomSchedule = () => new ScheduleAdapter().toUiData();
 let globalPrevTimetable: Timetable | undefined = undefined;
@@ -90,7 +91,7 @@ function useScheduleModal() {
     const isTimeslotValid = new TimeslotAdapter(prevSchedule.timeSlots).validate();
 
     if (!isTimeslotValid) {
-      useToastNotification.getState().addToast('시작 시간이 종료 시간보다 늦지 않아야 합니다.', 'timeslot-validation');
+      useToastNotification.getState().addToast('종료 시간은 시작 시간보다 늦어야 합니다.', 'timeslot-validation');
       return;
     }
 
@@ -121,20 +122,22 @@ function useScheduleModal() {
       createScheduleData(
         { schedule },
         {
-          onError: () =>
-            useToastNotification
-              .getState()
-              .addToast('과목 추가에 실패했습니다. 다시 시도해주세요.', 'schedule-create-error'),
+          onError: error =>
+            showTimetableApiErrorToast(error, {
+              fallbackMessage: '과목 추가에 실패했습니다. 다시 시도해주세요.',
+              tag: 'schedule-create-error',
+            }),
         },
       );
     } else if (mode === ScheduleMutateType.EDIT) {
       updateScheduleData(
         { schedule },
         {
-          onError: () =>
-            useToastNotification
-              .getState()
-              .addToast('과목 수정에 실패했습니다. 다시 시도해주세요.', 'schedule-update-error'),
+          onError: error =>
+            showTimetableApiErrorToast(error, {
+              fallbackMessage: '과목 수정에 실패했습니다. 다시 시도해주세요.',
+              tag: 'schedule-update-error',
+            }),
         },
       );
       changeScheduleData({ ...getInitCustomSchedule() }, ScheduleMutateType.NONE);
@@ -153,10 +156,11 @@ function useScheduleModal() {
     deleteScheduleData(
       { schedule },
       {
-        onError: () =>
-          useToastNotification
-            .getState()
-            .addToast('과목 삭제에 실패했습니다. 다시 시도해주세요.', 'schedule-delete-error'),
+        onError: error =>
+          showTimetableApiErrorToast(error, {
+            fallbackMessage: '과목 삭제에 실패했습니다. 다시 시도해주세요.',
+            tag: 'schedule-delete-error',
+          }),
       },
     );
 

--- a/packages/client/src/features/timetable/lib/useScheduleModal.ts
+++ b/packages/client/src/features/timetable/lib/useScheduleModal.ts
@@ -105,6 +105,17 @@ function useScheduleModal() {
 
     // 생성 및 수정 로직
     if (mode === ScheduleMutateType.CREATE) {
+      if (prevSchedule.scheduleType === 'official') {
+        const timetableData = queryClient.getQueryData<Timetable>(['timetableData', timetableId]);
+        const isDuplicate = timetableData?.schedules.some(
+          s => s.scheduleType === 'official' && s.subjectId === prevSchedule.subjectId,
+        );
+        if (isDuplicate) {
+          useToastNotification.getState().addToast('이미 시간표에 추가된 과목입니다.', 'duplicate-subject');
+          return;
+        }
+      }
+
       // 생성중인 Schedule 구분 용 - unique negative id 생성
       schedule.scheduleId = getUniqueNegativeId(globalPrevTimetable?.schedules ?? []);
       createScheduleData(

--- a/packages/client/src/features/timetable/lib/useScheduleModal.ts
+++ b/packages/client/src/features/timetable/lib/useScheduleModal.ts
@@ -124,7 +124,7 @@ function useScheduleModal() {
           onError: () =>
             useToastNotification
               .getState()
-              .addToast('수업 추가에 실패했습니다. 다시 시도해주세요.', 'schedule-create-error'),
+              .addToast('과목 추가에 실패했습니다. 다시 시도해주세요.', 'schedule-create-error'),
         },
       );
     } else if (mode === ScheduleMutateType.EDIT) {
@@ -134,7 +134,7 @@ function useScheduleModal() {
           onError: () =>
             useToastNotification
               .getState()
-              .addToast('수업 수정에 실패했습니다. 다시 시도해주세요.', 'schedule-update-error'),
+              .addToast('과목 수정에 실패했습니다. 다시 시도해주세요.', 'schedule-update-error'),
         },
       );
       changeScheduleData({ ...getInitCustomSchedule() }, ScheduleMutateType.NONE);
@@ -156,7 +156,7 @@ function useScheduleModal() {
         onError: () =>
           useToastNotification
             .getState()
-            .addToast('수업 삭제에 실패했습니다. 다시 시도해주세요.', 'schedule-delete-error'),
+            .addToast('과목 삭제에 실패했습니다. 다시 시도해주세요.', 'schedule-delete-error'),
       },
     );
 

--- a/packages/client/src/features/timetable/ui/DeleteConfirmationActions.tsx
+++ b/packages/client/src/features/timetable/ui/DeleteConfirmationActions.tsx
@@ -1,0 +1,25 @@
+import type { MouseEventHandler } from 'react';
+import { Button } from '@allcll/allcll-ui';
+
+interface DeleteConfirmationActionsProps {
+  message: string;
+  size: 'small' | 'medium';
+  onCancel: MouseEventHandler<HTMLButtonElement>;
+  onConfirm: () => void;
+}
+
+function DeleteConfirmationActions({ message, size, onCancel, onConfirm }: DeleteConfirmationActionsProps) {
+  return (
+    <>
+      <span className="self-center text-sm text-gray-600">{message}</span>
+      <Button type="button" variant="secondary" size={size} onClick={onCancel}>
+        취소
+      </Button>
+      <Button type="button" variant="danger" size={size} onClick={onConfirm}>
+        삭제
+      </Button>
+    </>
+  );
+}
+
+export default DeleteConfirmationActions;

--- a/packages/client/src/features/timetable/ui/EditTimetable.tsx
+++ b/packages/client/src/features/timetable/ui/EditTimetable.tsx
@@ -5,6 +5,7 @@ import useToastNotification from '@/features/notification/model/useToastNotifica
 import { Button, Chip, Dialog, Grid, Label, TextField } from '@allcll/allcll-ui';
 import { SEMESTERS } from '@/entities/semester/api/semester.ts';
 import useServiceSemester from '@/entities/semester/model/useServiceSemester';
+import { showTimetableApiErrorToast } from '../lib/showTimetableApiErrorToast';
 
 interface IEditTimetable {
   onClose: () => void;
@@ -32,7 +33,13 @@ function EditTimetable({ onClose, type }: Readonly<IEditTimetable>) {
     if (timeTable && type === 'edit') {
       updateTimetable(
         { timeTableId: timeTable.timeTableId, timeTableName: timeTableName },
-        { onError: () => addToast('시간표 수정에 실패했습니다. 다시 시도해주세요.', 'timetable-update-error') },
+        {
+          onError: error =>
+            showTimetableApiErrorToast(error, {
+              fallbackMessage: '시간표 수정에 실패했습니다. 다시 시도해주세요.',
+              tag: 'timetable-update-error',
+            }),
+        },
       );
       onClose();
       return;
@@ -40,7 +47,13 @@ function EditTimetable({ onClose, type }: Readonly<IEditTimetable>) {
     if (type === 'create') {
       createTimetable(
         { timeTableName: timeTableName, semesterCode: selectedSemester },
-        { onError: () => addToast('시간표 생성에 실패했습니다. 다시 시도해주세요.', 'timetable-create-error') },
+        {
+          onError: error =>
+            showTimetableApiErrorToast(error, {
+              fallbackMessage: '시간표 생성에 실패했습니다. 다시 시도해주세요.',
+              tag: 'timetable-create-error',
+            }),
+        },
       );
       onClose();
     }

--- a/packages/client/src/features/timetable/ui/EditTimetable.tsx
+++ b/packages/client/src/features/timetable/ui/EditTimetable.tsx
@@ -16,10 +16,10 @@ interface IEditTimetable {
 }
 
 function EditTimetable({ onClose, type }: Readonly<IEditTimetable>) {
-  const [timeTableName, setTimeTableName] = useState('');
-
   const timeTable = useScheduleState(state => state.currentTimetable);
   const currentSemester = useServiceSemester();
+
+  const [timeTableName, setTimeTableName] = useState(timeTable?.timeTableName ?? '');
 
   const [selectedSemester, setSelectedSemester] = useState(
     timeTable?.semesterCode ?? currentSemester.data?.semesterCode ?? '',

--- a/packages/client/src/features/timetable/ui/EditTimetable.tsx
+++ b/packages/client/src/features/timetable/ui/EditTimetable.tsx
@@ -5,7 +5,7 @@ import useToastNotification from '@/features/notification/model/useToastNotifica
 import { Button, Chip, Dialog, Grid, Label, TextField } from '@allcll/allcll-ui';
 import { SEMESTERS } from '@/entities/semester/api/semester.ts';
 import useServiceSemester from '@/entities/semester/model/useServiceSemester';
-import { showTimetableApiErrorToast } from '../lib/showTimetableApiErrorToast';
+import { showTimetableApiErrorToast, showTimetableApiSuccessToast } from '../lib/showTimetableApiErrorToast';
 
 interface IEditTimetable {
   onClose: () => void;
@@ -22,8 +22,20 @@ function EditTimetable({ onClose, type }: Readonly<IEditTimetable>) {
     timeTable?.semesterCode ?? currentSemester.data?.semesterCode ?? '',
   );
 
-  const { mutate: updateTimetable } = useUpdateTimetable();
-  const { mutate: createTimetable } = useCreateTimetable();
+  const { mutate: updateTimetable } = useUpdateTimetable({
+    onSuccess: () =>
+      showTimetableApiSuccessToast({
+        message: '시간표를 수정했습니다.',
+        tag: 'timetable-update-success',
+      }),
+  });
+  const { mutate: createTimetable } = useCreateTimetable({
+    onSuccess: () =>
+      showTimetableApiSuccessToast({
+        message: '시간표를 생성했습니다.',
+        tag: 'timetable-create-success',
+      }),
+  });
 
   const addToast = useToastNotification.getState().addToast;
 

--- a/packages/client/src/features/timetable/ui/EditTimetable.tsx
+++ b/packages/client/src/features/timetable/ui/EditTimetable.tsx
@@ -5,6 +5,7 @@ import {
   useUpdateTimetable,
 } from '@/entities/timetable/api/useTimetableSchedules.ts';
 import { useScheduleState } from '@/features/timetable/model/useScheduleState.ts';
+import useToastNotification from '@/features/notification/model/useToastNotification.ts';
 import { Button, Chip, Dialog, Grid, Label, TextField } from '@allcll/allcll-ui';
 import { SEMESTERS } from '@/entities/semester/api/semester.ts';
 import useServiceSemester from '@/entities/semester/model/useServiceSemester';
@@ -28,9 +29,13 @@ function EditTimetable({ onClose, type }: Readonly<IEditTimetable>) {
   const { mutate: deleteTimetable } = useDeleteTimetable();
   const { mutate: createTimetable } = useCreateTimetable();
 
+  const addToast = useToastNotification.getState().addToast;
+
   const handleDeleteTimetable = () => {
     if (type === 'edit' && timeTable) {
-      deleteTimetable(timeTable.timeTableId);
+      deleteTimetable(timeTable.timeTableId, {
+        onError: () => addToast('시간표 삭제에 실패했습니다. 다시 시도해주세요.', 'timetable-delete-error'),
+      });
       onClose();
     }
   };
@@ -39,15 +44,18 @@ function EditTimetable({ onClose, type }: Readonly<IEditTimetable>) {
     e.preventDefault();
 
     if (timeTable && type === 'edit') {
-      updateTimetable({ timeTableId: timeTable.timeTableId, timeTableName: timeTableName });
+      updateTimetable(
+        { timeTableId: timeTable.timeTableId, timeTableName: timeTableName },
+        { onError: () => addToast('시간표 수정에 실패했습니다. 다시 시도해주세요.', 'timetable-update-error') },
+      );
       onClose();
       return;
     }
     if (type === 'create') {
-      createTimetable({
-        timeTableName: timeTableName,
-        semesterCode: selectedSemester,
-      });
+      createTimetable(
+        { timeTableName: timeTableName, semesterCode: selectedSemester },
+        { onError: () => addToast('시간표 생성에 실패했습니다. 다시 시도해주세요.', 'timetable-create-error') },
+      );
       onClose();
     }
   };
@@ -65,7 +73,7 @@ function EditTimetable({ onClose, type }: Readonly<IEditTimetable>) {
 
   const handleTimetableSemester = (semesterCode: string) => {
     if (type === 'edit') {
-      alert('학기는 수정할 수 없습니다.');
+      addToast('학기는 수정할 수 없습니다.', 'semester-edit-warning');
       return;
     }
 

--- a/packages/client/src/features/timetable/ui/EditTimetable.tsx
+++ b/packages/client/src/features/timetable/ui/EditTimetable.tsx
@@ -19,7 +19,7 @@ function EditTimetable({ onClose, type }: Readonly<IEditTimetable>) {
   const timeTable = useScheduleState(state => state.currentTimetable);
   const currentSemester = useServiceSemester();
 
-  const [timeTableName, setTimeTableName] = useState(timeTable?.timeTableName ?? '');
+  const [timeTableName, setTimeTableName] = useState(type === 'edit' ? (timeTable?.timeTableName ?? '') : '');
 
   const [selectedSemester, setSelectedSemester] = useState(
     timeTable?.semesterCode ?? currentSemester.data?.semesterCode ?? '',

--- a/packages/client/src/features/timetable/ui/EditTimetable.tsx
+++ b/packages/client/src/features/timetable/ui/EditTimetable.tsx
@@ -1,9 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import {
-  useCreateTimetable,
-  useDeleteTimetable,
-  useUpdateTimetable,
-} from '@/entities/timetable/api/useTimetableSchedules.ts';
+import { useCreateTimetable, useUpdateTimetable } from '@/entities/timetable/api/useTimetableSchedules.ts';
 import { useScheduleState } from '@/features/timetable/model/useScheduleState.ts';
 import useToastNotification from '@/features/notification/model/useToastNotification.ts';
 import { Button, Chip, Dialog, Grid, Label, TextField } from '@allcll/allcll-ui';
@@ -26,19 +22,9 @@ function EditTimetable({ onClose, type }: Readonly<IEditTimetable>) {
   );
 
   const { mutate: updateTimetable } = useUpdateTimetable();
-  const { mutate: deleteTimetable } = useDeleteTimetable();
   const { mutate: createTimetable } = useCreateTimetable();
 
   const addToast = useToastNotification.getState().addToast;
-
-  const handleDeleteTimetable = () => {
-    if (type === 'edit' && timeTable) {
-      deleteTimetable(timeTable.timeTableId, {
-        onError: () => addToast('시간표 삭제에 실패했습니다. 다시 시도해주세요.', 'timetable-delete-error'),
-      });
-      onClose();
-    }
-  };
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -111,18 +97,6 @@ function EditTimetable({ onClose, type }: Readonly<IEditTimetable>) {
           <Button type="submit" variant="primary" size="medium">
             저장
           </Button>
-
-          {timeTable && type === 'edit' && (
-            <Button
-              type="button"
-              variant="secondary"
-              textColor="secondary"
-              size="medium"
-              onClick={handleDeleteTimetable}
-            >
-              삭제
-            </Button>
-          )}
         </Dialog.Footer>
       </form>
     </Dialog>

--- a/packages/client/src/features/timetable/ui/ScheduleContentPanel.tsx
+++ b/packages/client/src/features/timetable/ui/ScheduleContentPanel.tsx
@@ -38,7 +38,7 @@ function ScheduleContentPanel() {
 
         <ScheduleFilter />
         <Button variant="text" size="small" onClick={() => openScheduleModal(initSchedule)}>
-          + 커스텀 일정 생성
+          + 커스텀 과목 생성
         </Button>
 
         <Flex direction="flex-col" className="h-full overflow-hidden overflow-y-auto">

--- a/packages/client/src/features/timetable/ui/ScheduleContentPanel.tsx
+++ b/packages/client/src/features/timetable/ui/ScheduleContentPanel.tsx
@@ -38,7 +38,7 @@ function ScheduleContentPanel() {
 
         <ScheduleFilter />
         <Button variant="text" size="small" onClick={() => openScheduleModal(initSchedule)}>
-          + 커스텀 과목 생성
+          + 커스텀 일정 생성
         </Button>
 
         <Flex direction="flex-col" className="h-full overflow-hidden overflow-y-auto">

--- a/packages/client/src/features/timetable/ui/ScheduleFormContent.tsx
+++ b/packages/client/src/features/timetable/ui/ScheduleFormContent.tsx
@@ -23,7 +23,7 @@ function ScheduleFormContent() {
   const textFields = [
     {
       id: 'subjectName',
-      name: '과목명',
+      name: '일정명',
       value: scheduleForm?.subjectName ?? '',
     },
     {

--- a/packages/client/src/features/timetable/ui/ScheduleFormModal.tsx
+++ b/packages/client/src/features/timetable/ui/ScheduleFormModal.tsx
@@ -40,7 +40,7 @@ function ScheduleFormModal() {
 
   return (
     <>
-      <Dialog title={`커스텀 과목 ${title}`} onClose={cancelSchedule} isOpen={true}>
+      <Dialog title={`커스텀 일정 ${title}`} onClose={cancelSchedule} isOpen={true}>
         <form onSubmit={handleSubmit} className="flex flex-col gap-5">
           <Dialog.Content>
             <ScheduleFormContent />
@@ -62,8 +62,8 @@ function ScheduleFormModal() {
 
       <ConfirmDialog
         isOpen={isDeleteOpen}
-        title="커스텀 과목 삭제"
-        description="해당 커스텀 과목을 삭제하시겠습니까?"
+        title="커스텀 일정 삭제"
+        description="해당 커스텀 일정을 삭제하시겠습니까?"
         confirmLabel="삭제"
         danger
         onConfirm={handleConfirmDelete}

--- a/packages/client/src/features/timetable/ui/ScheduleFormModal.tsx
+++ b/packages/client/src/features/timetable/ui/ScheduleFormModal.tsx
@@ -1,45 +1,34 @@
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import ScheduleFormContent from './ScheduleFormContent.tsx';
 import useScheduleModal, { useScheduleModalData } from '@/features/timetable/lib/useScheduleModal.ts';
 import { ScheduleMutateType } from '@/features/timetable/model/useScheduleState.ts';
 import { Button, Dialog } from '@allcll/allcll-ui';
 import useMobile from '@/shared/lib/useMobile.ts';
+import DeleteConfirmationActions from '@/features/timetable/ui/DeleteConfirmationActions.tsx';
+import useDeleteConfirmation from '@/features/timetable/lib/useDeleteConfirmation.ts';
 
 function ScheduleFormModal() {
-  const [isDeleteConfirming, setIsDeleteConfirming] = useState(false);
   const { modalActionType } = useScheduleModalData();
   const title = modalActionType === ScheduleMutateType.CREATE ? '생성' : '수정';
   const { saveSchedule, deleteSchedule, cancelSchedule } = useScheduleModal();
   const isMobile = useMobile();
-
-  const onKeyDown = (e: KeyboardEvent) => {
-    if (e.key === 'Escape') cancelSchedule(e);
-  };
+  const buttonSize = isMobile ? 'small' : 'medium';
+  const { isDeleteConfirming, requestDeleteConfirmation, cancelDeleteConfirmation, confirmDelete } =
+    useDeleteConfirmation(deleteSchedule);
 
   useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') cancelSchedule(e);
+    };
+
     document.addEventListener('keydown', onKeyDown);
     return () => {
       document.removeEventListener('keydown', onKeyDown);
     };
-  }, []);
+  }, [cancelSchedule]);
 
   const handleSubmit = (e: React.FormEvent) => {
     saveSchedule(e);
-  };
-
-  const handleDeleteSchedule = (e: React.MouseEvent<HTMLButtonElement>) => {
-    e.preventDefault();
-    setIsDeleteConfirming(true);
-  };
-
-  const handleCancelDeleteConfirmation = (e: React.MouseEvent<HTMLButtonElement>) => {
-    e.preventDefault();
-    e.stopPropagation();
-    setIsDeleteConfirming(false);
-  };
-
-  const handleConfirmDelete = () => {
-    deleteSchedule();
   };
 
   return (
@@ -51,34 +40,21 @@ function ScheduleFormModal() {
 
         <Dialog.Footer>
           {isDeleteConfirming ? (
-            <>
-              <span className="self-center text-sm text-gray-600">커스텀 일정을 삭제하시겠습니까?</span>
-              <Button
-                type="button"
-                variant="secondary"
-                size={isMobile ? 'small' : 'medium'}
-                onClick={handleCancelDeleteConfirmation}
-              >
-                취소
-              </Button>
-              <Button type="button" variant="danger" size={isMobile ? 'small' : 'medium'} onClick={handleConfirmDelete}>
-                삭제
-              </Button>
-            </>
+            <DeleteConfirmationActions
+              message="커스텀 일정을 삭제하시겠습니까?"
+              size={buttonSize}
+              onCancel={cancelDeleteConfirmation}
+              onConfirm={confirmDelete}
+            />
           ) : (
             <>
               {(modalActionType === ScheduleMutateType.EDIT || modalActionType === ScheduleMutateType.VIEW) && (
-                <Button
-                  type="button"
-                  variant="secondary"
-                  size={isMobile ? 'small' : 'medium'}
-                  onClick={handleDeleteSchedule}
-                >
+                <Button type="button" variant="secondary" size={buttonSize} onClick={requestDeleteConfirmation}>
                   삭제
                 </Button>
               )}
 
-              <Button type="submit" variant="primary" size={isMobile ? 'small' : 'medium'}>
+              <Button type="submit" variant="primary" size={buttonSize}>
                 저장
               </Button>
             </>

--- a/packages/client/src/features/timetable/ui/ScheduleFormModal.tsx
+++ b/packages/client/src/features/timetable/ui/ScheduleFormModal.tsx
@@ -1,11 +1,13 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import ScheduleFormContent from './ScheduleFormContent.tsx';
 import useScheduleModal, { useScheduleModalData } from '@/features/timetable/lib/useScheduleModal.ts';
 import { ScheduleMutateType } from '@/features/timetable/model/useScheduleState.ts';
 import { Button, Dialog } from '@allcll/allcll-ui';
 import useMobile from '@/shared/lib/useMobile.ts';
+import ConfirmDialog from '@/shared/ui/ConfirmDialog.tsx';
 
 function ScheduleFormModal() {
+  const [isDeleteOpen, setIsDeleteOpen] = useState(false);
   const { modalActionType } = useScheduleModalData();
   const title = modalActionType === ScheduleMutateType.CREATE ? '생성' : '수정';
   const { saveSchedule, deleteSchedule, cancelSchedule } = useScheduleModal();
@@ -27,29 +29,47 @@ function ScheduleFormModal() {
   };
 
   const handleDeleteSchedule = (e: React.MouseEvent<HTMLButtonElement>) => {
-    deleteSchedule(e);
+    e.preventDefault();
+    setIsDeleteOpen(true);
+  };
+
+  const handleConfirmDelete = () => {
+    setIsDeleteOpen(false);
+    requestAnimationFrame(() => deleteSchedule());
   };
 
   return (
-    <Dialog title={`커스텀 일정 ${title}`} onClose={cancelSchedule} isOpen={true}>
-      <form onSubmit={handleSubmit} className="flex flex-col gap-5">
-        <Dialog.Content>
-          <ScheduleFormContent />
-        </Dialog.Content>
+    <>
+      <Dialog title={`커스텀 과목 ${title}`} onClose={cancelSchedule} isOpen={true}>
+        <form onSubmit={handleSubmit} className="flex flex-col gap-5">
+          <Dialog.Content>
+            <ScheduleFormContent />
+          </Dialog.Content>
 
-        <Dialog.Footer>
-          {(modalActionType === ScheduleMutateType.EDIT || modalActionType === ScheduleMutateType.VIEW) && (
-            <Button variant="secondary" size={isMobile ? 'small' : 'medium'} onClick={handleDeleteSchedule}>
-              삭제
+          <Dialog.Footer>
+            {(modalActionType === ScheduleMutateType.EDIT || modalActionType === ScheduleMutateType.VIEW) && (
+              <Button variant="secondary" size={isMobile ? 'small' : 'medium'} onClick={handleDeleteSchedule}>
+                삭제
+              </Button>
+            )}
+
+            <Button type="submit" variant="primary" size={isMobile ? 'small' : 'medium'}>
+              저장
             </Button>
-          )}
+          </Dialog.Footer>
+        </form>
+      </Dialog>
 
-          <Button type="submit" variant="primary" size={isMobile ? 'small' : 'medium'}>
-            저장
-          </Button>
-        </Dialog.Footer>
-      </form>
-    </Dialog>
+      <ConfirmDialog
+        isOpen={isDeleteOpen}
+        title="커스텀 과목 삭제"
+        description="해당 커스텀 과목을 삭제하시겠습니까?"
+        confirmLabel="삭제"
+        danger
+        onConfirm={handleConfirmDelete}
+        onClose={() => setIsDeleteOpen(false)}
+      />
+    </>
   );
 }
 

--- a/packages/client/src/features/timetable/ui/ScheduleFormModal.tsx
+++ b/packages/client/src/features/timetable/ui/ScheduleFormModal.tsx
@@ -4,10 +4,9 @@ import useScheduleModal, { useScheduleModalData } from '@/features/timetable/lib
 import { ScheduleMutateType } from '@/features/timetable/model/useScheduleState.ts';
 import { Button, Dialog } from '@allcll/allcll-ui';
 import useMobile from '@/shared/lib/useMobile.ts';
-import ConfirmDialog from '@/shared/ui/ConfirmDialog.tsx';
 
 function ScheduleFormModal() {
-  const [isDeleteOpen, setIsDeleteOpen] = useState(false);
+  const [isDeleteConfirming, setIsDeleteConfirming] = useState(false);
   const { modalActionType } = useScheduleModalData();
   const title = modalActionType === ScheduleMutateType.CREATE ? '생성' : '수정';
   const { saveSchedule, deleteSchedule, cancelSchedule } = useScheduleModal();
@@ -30,46 +29,63 @@ function ScheduleFormModal() {
 
   const handleDeleteSchedule = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
-    setIsDeleteOpen(true);
+    setIsDeleteConfirming(true);
+  };
+
+  const handleCancelDeleteConfirmation = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setIsDeleteConfirming(false);
   };
 
   const handleConfirmDelete = () => {
-    setIsDeleteOpen(false);
-    requestAnimationFrame(() => deleteSchedule());
+    deleteSchedule();
   };
 
   return (
-    <>
-      <Dialog title={`커스텀 일정 ${title}`} onClose={cancelSchedule} isOpen={true}>
-        <form onSubmit={handleSubmit} className="flex flex-col gap-5">
-          <Dialog.Content>
-            <ScheduleFormContent />
-          </Dialog.Content>
+    <Dialog title={`커스텀 일정 ${title}`} onClose={cancelSchedule} isOpen={true}>
+      <form onSubmit={handleSubmit} className="flex flex-col gap-5">
+        <Dialog.Content>
+          <ScheduleFormContent />
+        </Dialog.Content>
 
-          <Dialog.Footer>
-            {(modalActionType === ScheduleMutateType.EDIT || modalActionType === ScheduleMutateType.VIEW) && (
-              <Button variant="secondary" size={isMobile ? 'small' : 'medium'} onClick={handleDeleteSchedule}>
+        <Dialog.Footer>
+          {isDeleteConfirming ? (
+            <>
+              <span className="self-center text-sm text-gray-600">커스텀 일정을 삭제하시겠습니까?</span>
+              <Button
+                type="button"
+                variant="secondary"
+                size={isMobile ? 'small' : 'medium'}
+                onClick={handleCancelDeleteConfirmation}
+              >
+                취소
+              </Button>
+              <Button type="button" variant="danger" size={isMobile ? 'small' : 'medium'} onClick={handleConfirmDelete}>
                 삭제
               </Button>
-            )}
+            </>
+          ) : (
+            <>
+              {(modalActionType === ScheduleMutateType.EDIT || modalActionType === ScheduleMutateType.VIEW) && (
+                <Button
+                  type="button"
+                  variant="secondary"
+                  size={isMobile ? 'small' : 'medium'}
+                  onClick={handleDeleteSchedule}
+                >
+                  삭제
+                </Button>
+              )}
 
-            <Button type="submit" variant="primary" size={isMobile ? 'small' : 'medium'}>
-              저장
-            </Button>
-          </Dialog.Footer>
-        </form>
-      </Dialog>
-
-      <ConfirmDialog
-        isOpen={isDeleteOpen}
-        title="커스텀 일정 삭제"
-        description="해당 커스텀 일정을 삭제하시겠습니까?"
-        confirmLabel="삭제"
-        danger
-        onConfirm={handleConfirmDelete}
-        onClose={() => setIsDeleteOpen(false)}
-      />
-    </>
+              <Button type="submit" variant="primary" size={isMobile ? 'small' : 'medium'}>
+                저장
+              </Button>
+            </>
+          )}
+        </Dialog.Footer>
+      </form>
+    </Dialog>
   );
 }
 

--- a/packages/client/src/features/timetable/ui/ScheduleInfoModal.tsx
+++ b/packages/client/src/features/timetable/ui/ScheduleInfoModal.tsx
@@ -1,13 +1,15 @@
+import { useState } from 'react';
 import useScheduleModal, { useScheduleModalData } from '@/features/timetable/lib/useScheduleModal.ts';
 import ClockGraySvg from '@/assets/clock-gray.svg?react';
 import HouseSvg from '@/assets/house.svg?react';
 import useSubject from '@/entities/subjects/model/useSubject.ts';
-import React from 'react';
 import { Button, Dialog, Flex } from '@allcll/allcll-ui';
 import { useBottomSheetStore } from '@/shared/model/useBottomSheetStore.ts';
 import { useSemesterParam } from '@/entities/semester/model/useSemesterParam';
+import ConfirmDialog from '@/shared/ui/ConfirmDialog.tsx';
 
 function ScheduleInfoModal() {
+  const [isDeleteOpen, setIsDeleteOpen] = useState(false);
   const semester = useSemesterParam();
 
   const { schedule } = useScheduleModalData();
@@ -15,43 +17,55 @@ function ScheduleInfoModal() {
   const closeBottomSheet = useBottomSheetStore(state => state.closeBottomSheet);
   const { data: subjects } = useSubject(semester);
 
-  const handleDeleteOfficialSchedule = (e: React.MouseEvent<HTMLButtonElement>) => {
-    const confirmed = confirm('해당 과목을 삭제하시겠습니까?');
-    if (!confirmed) return;
-
-    deleteSchedule(e);
+  const handleDeleteOfficialSchedule = () => {
+    setIsDeleteOpen(true);
   };
 
   const findSubjectById = subjects?.find(subject => subject.subjectId === schedule.subjectId);
 
   return (
-    <Dialog title={schedule.subjectName} onClose={() => closeBottomSheet('info')} isOpen={true}>
-      <Dialog.Content>
-        <Flex direction="flex-col" gap="gap-1" className="w-80 text-sm text-gray-500">
-          <p>{schedule.professorName ?? '교수 정보 없음'}</p>
+    <>
+      <Dialog title={schedule.subjectName} onClose={() => closeBottomSheet('info')} isOpen={true}>
+        <Dialog.Content>
+          <Flex direction="flex-col" gap="gap-1" className="w-80 text-sm text-gray-500">
+            <p>{schedule.professorName ?? '교수 정보 없음'}</p>
 
-          <Flex align="items-center" gap="gap-2">
-            <ClockGraySvg className="w-4 h-4 text-gray-400" />
-            <p>{findSubjectById?.lesnTime}</p>
+            <Flex align="items-center" gap="gap-2">
+              <ClockGraySvg className="w-4 h-4 text-gray-400" />
+              <p>{findSubjectById?.lesnTime}</p>
+            </Flex>
+
+            <Flex align="items-center" gap="gap-2">
+              <HouseSvg className="w-4 h-4 text-gray-400" />
+              <p>{findSubjectById?.lesnRoom ?? '장소 정보 없음'}</p>
+            </Flex>
+            <p>
+              {findSubjectById?.manageDeptNm} {findSubjectById?.studentYear + '학년'}{' '}
+              <span className="text-blue-500">{findSubjectById?.tmNum[0] + '학점'}</span>
+            </p>
           </Flex>
+        </Dialog.Content>
 
-          <Flex align="items-center" gap="gap-2">
-            <HouseSvg className="w-4 h-4 text-gray-400" />
-            <p>{findSubjectById?.lesnRoom ?? '장소 정보 없음'}</p>
-          </Flex>
-          <p>
-            {findSubjectById?.manageDeptNm} {findSubjectById?.studentYear + '학년'}{' '}
-            <span className="text-blue-500">{findSubjectById?.tmNum[0] + '학점'}</span>
-          </p>
-        </Flex>
-      </Dialog.Content>
+        <Dialog.Footer>
+          <Button variant="text" size="medium" textColor="secondary" onClick={handleDeleteOfficialSchedule}>
+            삭제
+          </Button>
+        </Dialog.Footer>
+      </Dialog>
 
-      <Dialog.Footer>
-        <Button variant="text" size="medium" textColor="secondary" onClick={handleDeleteOfficialSchedule}>
-          삭제
-        </Button>
-      </Dialog.Footer>
-    </Dialog>
+      <ConfirmDialog
+        isOpen={isDeleteOpen}
+        title="과목 삭제"
+        description="해당 과목을 삭제하시겠습니까?"
+        confirmLabel="삭제"
+        danger
+        onConfirm={() => {
+          deleteSchedule();
+          setIsDeleteOpen(false);
+        }}
+        onClose={() => setIsDeleteOpen(false)}
+      />
+    </>
   );
 }
 

--- a/packages/client/src/features/timetable/ui/ScheduleInfoModal.tsx
+++ b/packages/client/src/features/timetable/ui/ScheduleInfoModal.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import useScheduleModal, { useScheduleModalData } from '@/features/timetable/lib/useScheduleModal.ts';
 import ClockGraySvg from '@/assets/clock-gray.svg?react';
 import HouseSvg from '@/assets/house.svg?react';
@@ -6,29 +5,18 @@ import useSubject from '@/entities/subjects/model/useSubject.ts';
 import { Button, Dialog, Flex } from '@allcll/allcll-ui';
 import { useBottomSheetStore } from '@/shared/model/useBottomSheetStore.ts';
 import { useSemesterParam } from '@/entities/semester/model/useSemesterParam';
+import DeleteConfirmationActions from '@/features/timetable/ui/DeleteConfirmationActions.tsx';
+import useDeleteConfirmation from '@/features/timetable/lib/useDeleteConfirmation.ts';
 
 function ScheduleInfoModal() {
-  const [isDeleteConfirming, setIsDeleteConfirming] = useState(false);
   const semester = useSemesterParam();
 
   const { schedule } = useScheduleModalData();
   const { deleteSchedule } = useScheduleModal();
   const closeBottomSheet = useBottomSheetStore(state => state.closeBottomSheet);
   const { data: subjects } = useSubject(semester);
-
-  const handleDeleteOfficialSchedule = () => {
-    setIsDeleteConfirming(true);
-  };
-
-  const handleCancelDeleteConfirmation = (e: React.MouseEvent<HTMLButtonElement>) => {
-    e.preventDefault();
-    e.stopPropagation();
-    setIsDeleteConfirming(false);
-  };
-
-  const handleConfirmDelete = () => {
-    deleteSchedule();
-  };
+  const { isDeleteConfirming, requestDeleteConfirmation, cancelDeleteConfirmation, confirmDelete } =
+    useDeleteConfirmation(deleteSchedule);
 
   const findSubjectById = subjects?.find(subject => subject.subjectId === schedule.subjectId);
 
@@ -56,17 +44,14 @@ function ScheduleInfoModal() {
 
       <Dialog.Footer>
         {isDeleteConfirming ? (
-          <>
-            <span className="self-center text-sm text-gray-600">과목을 삭제하시겠습니까?</span>
-            <Button type="button" variant="secondary" size="medium" onClick={handleCancelDeleteConfirmation}>
-              취소
-            </Button>
-            <Button type="button" variant="danger" size="medium" onClick={handleConfirmDelete}>
-              삭제
-            </Button>
-          </>
+          <DeleteConfirmationActions
+            message="과목을 삭제하시겠습니까?"
+            size="medium"
+            onCancel={cancelDeleteConfirmation}
+            onConfirm={confirmDelete}
+          />
         ) : (
-          <Button variant="text" size="medium" textColor="secondary" onClick={handleDeleteOfficialSchedule}>
+          <Button variant="text" size="medium" textColor="secondary" onClick={requestDeleteConfirmation}>
             삭제
           </Button>
         )}

--- a/packages/client/src/features/timetable/ui/ScheduleInfoModal.tsx
+++ b/packages/client/src/features/timetable/ui/ScheduleInfoModal.tsx
@@ -21,6 +21,11 @@ function ScheduleInfoModal() {
     setIsDeleteOpen(true);
   };
 
+  const handleConfirmDelete = () => {
+    setIsDeleteOpen(false);
+    requestAnimationFrame(() => deleteSchedule());
+  };
+
   const findSubjectById = subjects?.find(subject => subject.subjectId === schedule.subjectId);
 
   return (
@@ -59,10 +64,7 @@ function ScheduleInfoModal() {
         description="해당 과목을 삭제하시겠습니까?"
         confirmLabel="삭제"
         danger
-        onConfirm={() => {
-          deleteSchedule();
-          setIsDeleteOpen(false);
-        }}
+        onConfirm={handleConfirmDelete}
         onClose={() => setIsDeleteOpen(false)}
       />
     </>

--- a/packages/client/src/features/timetable/ui/ScheduleInfoModal.tsx
+++ b/packages/client/src/features/timetable/ui/ScheduleInfoModal.tsx
@@ -6,10 +6,9 @@ import useSubject from '@/entities/subjects/model/useSubject.ts';
 import { Button, Dialog, Flex } from '@allcll/allcll-ui';
 import { useBottomSheetStore } from '@/shared/model/useBottomSheetStore.ts';
 import { useSemesterParam } from '@/entities/semester/model/useSemesterParam';
-import ConfirmDialog from '@/shared/ui/ConfirmDialog.tsx';
 
 function ScheduleInfoModal() {
-  const [isDeleteOpen, setIsDeleteOpen] = useState(false);
+  const [isDeleteConfirming, setIsDeleteConfirming] = useState(false);
   const semester = useSemesterParam();
 
   const { schedule } = useScheduleModalData();
@@ -18,56 +17,61 @@ function ScheduleInfoModal() {
   const { data: subjects } = useSubject(semester);
 
   const handleDeleteOfficialSchedule = () => {
-    setIsDeleteOpen(true);
+    setIsDeleteConfirming(true);
+  };
+
+  const handleCancelDeleteConfirmation = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setIsDeleteConfirming(false);
   };
 
   const handleConfirmDelete = () => {
-    setIsDeleteOpen(false);
-    requestAnimationFrame(() => deleteSchedule());
+    deleteSchedule();
   };
 
   const findSubjectById = subjects?.find(subject => subject.subjectId === schedule.subjectId);
 
   return (
-    <>
-      <Dialog title={schedule.subjectName} onClose={() => closeBottomSheet('info')} isOpen={true}>
-        <Dialog.Content>
-          <Flex direction="flex-col" gap="gap-1" className="w-80 text-sm text-gray-500">
-            <p>{schedule.professorName ?? '교수 정보 없음'}</p>
+    <Dialog title={schedule.subjectName} onClose={() => closeBottomSheet('info')} isOpen={true}>
+      <Dialog.Content>
+        <Flex direction="flex-col" gap="gap-1" className="w-80 text-sm text-gray-500">
+          <p>{schedule.professorName ?? '교수 정보 없음'}</p>
 
-            <Flex align="items-center" gap="gap-2">
-              <ClockGraySvg className="w-4 h-4 text-gray-400" />
-              <p>{findSubjectById?.lesnTime}</p>
-            </Flex>
-
-            <Flex align="items-center" gap="gap-2">
-              <HouseSvg className="w-4 h-4 text-gray-400" />
-              <p>{findSubjectById?.lesnRoom ?? '장소 정보 없음'}</p>
-            </Flex>
-            <p>
-              {findSubjectById?.manageDeptNm} {findSubjectById?.studentYear + '학년'}{' '}
-              <span className="text-blue-500">{findSubjectById?.tmNum[0] + '학점'}</span>
-            </p>
+          <Flex align="items-center" gap="gap-2">
+            <ClockGraySvg className="w-4 h-4 text-gray-400" />
+            <p>{findSubjectById?.lesnTime}</p>
           </Flex>
-        </Dialog.Content>
 
-        <Dialog.Footer>
+          <Flex align="items-center" gap="gap-2">
+            <HouseSvg className="w-4 h-4 text-gray-400" />
+            <p>{findSubjectById?.lesnRoom ?? '장소 정보 없음'}</p>
+          </Flex>
+          <p>
+            {findSubjectById?.manageDeptNm} {findSubjectById?.studentYear + '학년'}{' '}
+            <span className="text-blue-500">{findSubjectById?.tmNum[0] + '학점'}</span>
+          </p>
+        </Flex>
+      </Dialog.Content>
+
+      <Dialog.Footer>
+        {isDeleteConfirming ? (
+          <>
+            <span className="self-center text-sm text-gray-600">과목을 삭제하시겠습니까?</span>
+            <Button type="button" variant="secondary" size="medium" onClick={handleCancelDeleteConfirmation}>
+              취소
+            </Button>
+            <Button type="button" variant="danger" size="medium" onClick={handleConfirmDelete}>
+              삭제
+            </Button>
+          </>
+        ) : (
           <Button variant="text" size="medium" textColor="secondary" onClick={handleDeleteOfficialSchedule}>
             삭제
           </Button>
-        </Dialog.Footer>
-      </Dialog>
-
-      <ConfirmDialog
-        isOpen={isDeleteOpen}
-        title="과목 삭제"
-        description="해당 과목을 삭제하시겠습니까?"
-        confirmLabel="삭제"
-        danger
-        onConfirm={handleConfirmDelete}
-        onClose={() => setIsDeleteOpen(false)}
-      />
-    </>
+        )}
+      </Dialog.Footer>
+    </Dialog>
   );
 }
 

--- a/packages/client/src/features/timetable/ui/errors/ZeroListError.tsx
+++ b/packages/client/src/features/timetable/ui/errors/ZeroListError.tsx
@@ -11,7 +11,7 @@ function ZeroListError() {
     <div className="flex flex-col items-center gap-3 pt-5">
       <ZeroContent
         title="검색 결과가 없습니다."
-        description="찾으시는 과목이 없으신가요? 과목을 직접 등록해주세요."
+        description="찾으시는 과목이 없으신가요? 커스텀 일정을 직접 등록해주세요."
       />
 
       <Button variant="primary" size="medium" onClick={() => openScheduleModal(initSchedule)}>

--- a/packages/client/src/shared/ui/ConfirmDialog.tsx
+++ b/packages/client/src/shared/ui/ConfirmDialog.tsx
@@ -1,0 +1,43 @@
+import { Button, Dialog, Flex } from '@allcll/allcll-ui';
+
+interface ConfirmDialogProps {
+  isOpen: boolean;
+  title: string;
+  description: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  danger?: boolean;
+  onConfirm: () => void;
+  onClose: () => void;
+}
+
+function ConfirmDialog({
+  isOpen,
+  title,
+  description,
+  confirmLabel = '확인',
+  cancelLabel = '취소',
+  danger = false,
+  onConfirm,
+  onClose,
+}: ConfirmDialogProps) {
+  return (
+    <Dialog isOpen={isOpen} title={title} onClose={onClose}>
+      <Dialog.Content>
+        <p className="text-sm text-gray-600 min-w-60">{description}</p>
+      </Dialog.Content>
+      <Dialog.Footer>
+        <Flex gap="gap-2" justify="justify-end">
+          <Button variant="secondary" size="medium" onClick={onClose}>
+            {cancelLabel}
+          </Button>
+          <Button variant={danger ? 'danger' : 'secondary'} size="medium" onClick={onConfirm}>
+            {confirmLabel}
+          </Button>
+        </Flex>
+      </Dialog.Footer>
+    </Dialog>
+  );
+}
+
+export default ConfirmDialog;

--- a/packages/client/src/widgets/bottomSheet/ui/ScheduleDetailBottomSheet.tsx
+++ b/packages/client/src/widgets/bottomSheet/ui/ScheduleDetailBottomSheet.tsx
@@ -7,10 +7,9 @@ import { Button, Flex, Heading } from '@allcll/allcll-ui';
 import BottomSheet from '@/shared/ui/bottomsheet/BottomSheet';
 import BottomSheetHeader from '@/shared/ui/bottomsheet/BottomSheetHeader';
 import { useSemesterParam } from '@/entities/semester/model/useSemesterParam';
-import ConfirmDialog from '@/shared/ui/ConfirmDialog.tsx';
 
 function ScheduleInfoBottomSheet() {
-  const [isDeleteOpen, setIsDeleteOpen] = useState(false);
+  const [isDeleteConfirming, setIsDeleteConfirming] = useState(false);
   const semester = useSemesterParam();
 
   const { schedule } = useScheduleModalData();
@@ -18,63 +17,68 @@ function ScheduleInfoBottomSheet() {
   const { data: subjects } = useSubject(semester);
 
   const handleDeleteOfficialSchedule = () => {
-    setIsDeleteOpen(true);
+    setIsDeleteConfirming(true);
+  };
+
+  const handleCancelDeleteConfirmation = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setIsDeleteConfirming(false);
   };
 
   const handleConfirmDelete = () => {
-    setIsDeleteOpen(false);
-    requestAnimationFrame(() => deleteSchedule());
+    deleteSchedule();
   };
 
   const findSubjectById = subjects?.find(subject => subject.subjectId === schedule.subjectId);
 
   return (
-    <>
-      <BottomSheet>
-        <BottomSheetHeader headerType="close" onClose={cancelSchedule} />
-        <Flex direction="flex-col" className="px-2 py-3 w-full text-sm text-gray-500 gap-2">
-          <Heading level={3}>{schedule.subjectName}</Heading>
-          <p className="text-sm text-gray-500">{schedule.professorName ?? '교수 정보 없음'}</p>
+    <BottomSheet>
+      <BottomSheetHeader headerType="close" onClose={cancelSchedule} />
+      <Flex direction="flex-col" className="px-2 py-3 w-full text-sm text-gray-500 gap-2">
+        <Heading level={3}>{schedule.subjectName}</Heading>
+        <p className="text-sm text-gray-500">{schedule.professorName ?? '교수 정보 없음'}</p>
 
-          <Flex align="items-center">
-            <ClockGraySvg className="w-4 h-4 text-gray-400" />
-            <span>{findSubjectById?.lesnTime}</span>
-          </Flex>
+        <Flex align="items-center">
+          <ClockGraySvg className="w-4 h-4 text-gray-400" />
+          <span>{findSubjectById?.lesnTime}</span>
+        </Flex>
 
-          <Flex align="items-center">
-            <HouseSvg className="w-4 h-4 text-gray-400" />
-            <span>{findSubjectById?.lesnRoom ?? '장소 정보 없음'}</span>
-          </Flex>
+        <Flex align="items-center">
+          <HouseSvg className="w-4 h-4 text-gray-400" />
+          <span>{findSubjectById?.lesnRoom ?? '장소 정보 없음'}</span>
+        </Flex>
 
-          <Flex>
-            <span>{findSubjectById?.manageDeptNm}</span>
-            <span> {findSubjectById?.studentYear + '학년'}</span>
-            <span className="text-blue-500 text-sm">{findSubjectById?.tmNum[0] + '학점'}</span>
-          </Flex>
+        <Flex>
+          <span>{findSubjectById?.manageDeptNm}</span>
+          <span> {findSubjectById?.studentYear + '학년'}</span>
+          <span className="text-blue-500 text-sm">{findSubjectById?.tmNum[0] + '학점'}</span>
+        </Flex>
 
-          <Flex>
-            <span>{findSubjectById?.curiTypeCdNm ?? ''} </span>
-            <span>{findSubjectById?.remark ?? ''}</span>
-          </Flex>
+        <Flex>
+          <span>{findSubjectById?.curiTypeCdNm ?? ''} </span>
+          <span>{findSubjectById?.remark ?? ''}</span>
+        </Flex>
 
-          <Flex justify="justify-end" className="px-2">
+        <Flex justify="justify-end" align="items-center" gap="gap-2" className="px-2">
+          {isDeleteConfirming ? (
+            <>
+              <span className="self-center text-sm text-gray-600">과목을 삭제하시겠습니까?</span>
+              <Button type="button" variant="secondary" size="medium" onClick={handleCancelDeleteConfirmation}>
+                취소
+              </Button>
+              <Button type="button" variant="danger" size="medium" onClick={handleConfirmDelete}>
+                삭제
+              </Button>
+            </>
+          ) : (
             <Button variant="text" size="medium" textColor="secondary" onClick={handleDeleteOfficialSchedule}>
               삭제
             </Button>
-          </Flex>
+          )}
         </Flex>
-      </BottomSheet>
-
-      <ConfirmDialog
-        isOpen={isDeleteOpen}
-        title="과목 삭제"
-        description="해당 과목을 삭제하시겠습니까?"
-        confirmLabel="삭제"
-        danger
-        onConfirm={handleConfirmDelete}
-        onClose={() => setIsDeleteOpen(false)}
-      />
-    </>
+      </Flex>
+    </BottomSheet>
   );
 }
 

--- a/packages/client/src/widgets/bottomSheet/ui/ScheduleDetailBottomSheet.tsx
+++ b/packages/client/src/widgets/bottomSheet/ui/ScheduleDetailBottomSheet.tsx
@@ -21,6 +21,11 @@ function ScheduleInfoBottomSheet() {
     setIsDeleteOpen(true);
   };
 
+  const handleConfirmDelete = () => {
+    setIsDeleteOpen(false);
+    requestAnimationFrame(() => deleteSchedule());
+  };
+
   const findSubjectById = subjects?.find(subject => subject.subjectId === schedule.subjectId);
 
   return (
@@ -66,10 +71,7 @@ function ScheduleInfoBottomSheet() {
         description="해당 과목을 삭제하시겠습니까?"
         confirmLabel="삭제"
         danger
-        onConfirm={() => {
-          deleteSchedule();
-          setIsDeleteOpen(false);
-        }}
+        onConfirm={handleConfirmDelete}
         onClose={() => setIsDeleteOpen(false)}
       />
     </>

--- a/packages/client/src/widgets/bottomSheet/ui/ScheduleDetailBottomSheet.tsx
+++ b/packages/client/src/widgets/bottomSheet/ui/ScheduleDetailBottomSheet.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { useState } from 'react';
 import ClockGraySvg from '@/assets/clock-gray.svg?react';
 import HouseSvg from '@/assets/house.svg?react';
 import useSubject from '@/entities/subjects/model/useSubject.ts';
@@ -7,58 +7,72 @@ import { Button, Flex, Heading } from '@allcll/allcll-ui';
 import BottomSheet from '@/shared/ui/bottomsheet/BottomSheet';
 import BottomSheetHeader from '@/shared/ui/bottomsheet/BottomSheetHeader';
 import { useSemesterParam } from '@/entities/semester/model/useSemesterParam';
+import ConfirmDialog from '@/shared/ui/ConfirmDialog.tsx';
 
 function ScheduleInfoBottomSheet() {
+  const [isDeleteOpen, setIsDeleteOpen] = useState(false);
   const semester = useSemesterParam();
 
   const { schedule } = useScheduleModalData();
   const { deleteSchedule, cancelSchedule } = useScheduleModal();
   const { data: subjects } = useSubject(semester);
 
-  const handleDeleteOfficialSchedule = (e: React.MouseEvent<HTMLButtonElement>) => {
-    const confirmed = confirm('해당 과목을 삭제하시겠습니까?');
-    if (!confirmed) return;
-
-    deleteSchedule(e);
+  const handleDeleteOfficialSchedule = () => {
+    setIsDeleteOpen(true);
   };
 
   const findSubjectById = subjects?.find(subject => subject.subjectId === schedule.subjectId);
 
   return (
-    <BottomSheet>
-      <BottomSheetHeader headerType="close" onClose={cancelSchedule} />
-      <Flex direction="flex-col" className="px-2 py-3 w-full text-sm text-gray-500 gap-2">
-        <Heading level={3}>{schedule.subjectName}</Heading>
-        <p className="text-sm text-gray-500">{schedule.professorName ?? '교수 정보 없음'}</p>
+    <>
+      <BottomSheet>
+        <BottomSheetHeader headerType="close" onClose={cancelSchedule} />
+        <Flex direction="flex-col" className="px-2 py-3 w-full text-sm text-gray-500 gap-2">
+          <Heading level={3}>{schedule.subjectName}</Heading>
+          <p className="text-sm text-gray-500">{schedule.professorName ?? '교수 정보 없음'}</p>
 
-        <Flex align="items-center">
-          <ClockGraySvg className="w-4 h-4 text-gray-400" />
-          <span>{findSubjectById?.lesnTime}</span>
-        </Flex>
+          <Flex align="items-center">
+            <ClockGraySvg className="w-4 h-4 text-gray-400" />
+            <span>{findSubjectById?.lesnTime}</span>
+          </Flex>
 
-        <Flex align="items-center">
-          <HouseSvg className="w-4 h-4 text-gray-400" />
-          <span>{findSubjectById?.lesnRoom ?? '장소 정보 없음'}</span>
-        </Flex>
+          <Flex align="items-center">
+            <HouseSvg className="w-4 h-4 text-gray-400" />
+            <span>{findSubjectById?.lesnRoom ?? '장소 정보 없음'}</span>
+          </Flex>
 
-        <Flex>
-          <span>{findSubjectById?.manageDeptNm}</span>
-          <span> {findSubjectById?.studentYear + '학년'}</span>
-          <span className="text-blue-500 text-sm">{findSubjectById?.tmNum[0] + '학점'}</span>
-        </Flex>
+          <Flex>
+            <span>{findSubjectById?.manageDeptNm}</span>
+            <span> {findSubjectById?.studentYear + '학년'}</span>
+            <span className="text-blue-500 text-sm">{findSubjectById?.tmNum[0] + '학점'}</span>
+          </Flex>
 
-        <Flex>
-          <span>{findSubjectById?.curiTypeCdNm ?? ''} </span>
-          <span>{findSubjectById?.remark ?? ''}</span>
-        </Flex>
+          <Flex>
+            <span>{findSubjectById?.curiTypeCdNm ?? ''} </span>
+            <span>{findSubjectById?.remark ?? ''}</span>
+          </Flex>
 
-        <Flex justify="justify-end" className="px-2">
-          <Button variant="text" size="medium" textColor="secondary" onClick={handleDeleteOfficialSchedule}>
-            삭제
-          </Button>
+          <Flex justify="justify-end" className="px-2">
+            <Button variant="text" size="medium" textColor="secondary" onClick={handleDeleteOfficialSchedule}>
+              삭제
+            </Button>
+          </Flex>
         </Flex>
-      </Flex>
-    </BottomSheet>
+      </BottomSheet>
+
+      <ConfirmDialog
+        isOpen={isDeleteOpen}
+        title="과목 삭제"
+        description="해당 과목을 삭제하시겠습니까?"
+        confirmLabel="삭제"
+        danger
+        onConfirm={() => {
+          deleteSchedule();
+          setIsDeleteOpen(false);
+        }}
+        onClose={() => setIsDeleteOpen(false)}
+      />
+    </>
   );
 }
 

--- a/packages/client/src/widgets/bottomSheet/ui/ScheduleDetailBottomSheet.tsx
+++ b/packages/client/src/widgets/bottomSheet/ui/ScheduleDetailBottomSheet.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import ClockGraySvg from '@/assets/clock-gray.svg?react';
 import HouseSvg from '@/assets/house.svg?react';
 import useSubject from '@/entities/subjects/model/useSubject.ts';
@@ -7,28 +6,17 @@ import { Button, Flex, Heading } from '@allcll/allcll-ui';
 import BottomSheet from '@/shared/ui/bottomsheet/BottomSheet';
 import BottomSheetHeader from '@/shared/ui/bottomsheet/BottomSheetHeader';
 import { useSemesterParam } from '@/entities/semester/model/useSemesterParam';
+import DeleteConfirmationActions from '@/features/timetable/ui/DeleteConfirmationActions';
+import useDeleteConfirmation from '@/features/timetable/lib/useDeleteConfirmation';
 
 function ScheduleInfoBottomSheet() {
-  const [isDeleteConfirming, setIsDeleteConfirming] = useState(false);
   const semester = useSemesterParam();
 
   const { schedule } = useScheduleModalData();
   const { deleteSchedule, cancelSchedule } = useScheduleModal();
   const { data: subjects } = useSubject(semester);
-
-  const handleDeleteOfficialSchedule = () => {
-    setIsDeleteConfirming(true);
-  };
-
-  const handleCancelDeleteConfirmation = (e: React.MouseEvent<HTMLButtonElement>) => {
-    e.preventDefault();
-    e.stopPropagation();
-    setIsDeleteConfirming(false);
-  };
-
-  const handleConfirmDelete = () => {
-    deleteSchedule();
-  };
+  const { isDeleteConfirming, requestDeleteConfirmation, cancelDeleteConfirmation, confirmDelete } =
+    useDeleteConfirmation(deleteSchedule);
 
   const findSubjectById = subjects?.find(subject => subject.subjectId === schedule.subjectId);
 
@@ -62,17 +50,14 @@ function ScheduleInfoBottomSheet() {
 
         <Flex justify="justify-end" align="items-center" gap="gap-2" className="px-2">
           {isDeleteConfirming ? (
-            <>
-              <span className="self-center text-sm text-gray-600">과목을 삭제하시겠습니까?</span>
-              <Button type="button" variant="secondary" size="medium" onClick={handleCancelDeleteConfirmation}>
-                취소
-              </Button>
-              <Button type="button" variant="danger" size="medium" onClick={handleConfirmDelete}>
-                삭제
-              </Button>
-            </>
+            <DeleteConfirmationActions
+              message="과목을 삭제하시겠습니까?"
+              size="medium"
+              onCancel={cancelDeleteConfirmation}
+              onConfirm={confirmDelete}
+            />
           ) : (
-            <Button variant="text" size="medium" textColor="secondary" onClick={handleDeleteOfficialSchedule}>
+            <Button variant="text" size="medium" textColor="secondary" onClick={requestDeleteConfirmation}>
               삭제
             </Button>
           )}

--- a/packages/client/src/widgets/bottomSheet/ui/ScheduleFormBottomSheet.tsx
+++ b/packages/client/src/widgets/bottomSheet/ui/ScheduleFormBottomSheet.tsx
@@ -37,7 +37,7 @@ function ScheduleFormBottomSheet() {
   return (
     <>
       <BottomSheet>
-        <BottomSheetHeader title={`커스텀 과목 ${title}`} headerType="close" onClose={handleCancelSchedule} />
+        <BottomSheetHeader title={`커스텀 일정 ${title}`} headerType="close" onClose={handleCancelSchedule} />
         <form onSubmit={handleSubmit} className="flex flex-col gap-5">
           <Flex direction="flex-col" className="py-5 px-2 overflow-y-auto max-h-[80vh]">
             <ScheduleFormContent />
@@ -59,8 +59,8 @@ function ScheduleFormBottomSheet() {
 
       <ConfirmDialog
         isOpen={isDeleteOpen}
-        title="커스텀 과목 삭제"
-        description="해당 커스텀 과목을 삭제하시겠습니까?"
+        title="커스텀 일정 삭제"
+        description="해당 커스텀 일정을 삭제하시겠습니까?"
         confirmLabel="삭제"
         danger
         onConfirm={handleConfirmDelete}

--- a/packages/client/src/widgets/bottomSheet/ui/ScheduleFormBottomSheet.tsx
+++ b/packages/client/src/widgets/bottomSheet/ui/ScheduleFormBottomSheet.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import useScheduleModal, { useScheduleModalData } from '@/features/timetable/lib/useScheduleModal.ts';
 import { ScheduleMutateType } from '@/features/timetable/model/useScheduleState.ts';
 import { Button, Flex } from '@allcll/allcll-ui';
@@ -6,8 +6,10 @@ import useMobile from '@/shared/lib/useMobile.ts';
 import BottomSheet from '@/shared/ui/bottomsheet/BottomSheet';
 import BottomSheetHeader from '@/shared/ui/bottomsheet/BottomSheetHeader';
 import ScheduleFormContent from '@/features/timetable/ui/ScheduleFormContent';
+import ConfirmDialog from '@/shared/ui/ConfirmDialog';
 
 function ScheduleFormBottomSheet() {
+  const [isDeleteOpen, setIsDeleteOpen] = useState(false);
   const { modalActionType } = useScheduleModalData();
   const { cancelSchedule, deleteSchedule, saveSchedule } = useScheduleModal();
 
@@ -22,27 +24,49 @@ function ScheduleFormBottomSheet() {
     saveSchedule(e);
   };
 
+  const handleDeleteSchedule = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    setIsDeleteOpen(true);
+  };
+
+  const handleConfirmDelete = () => {
+    setIsDeleteOpen(false);
+    requestAnimationFrame(() => deleteSchedule());
+  };
+
   return (
-    <BottomSheet>
-      <BottomSheetHeader title={`커스텀 일정 ${title}`} headerType="close" onClose={handleCancelSchedule} />
-      <form onSubmit={handleSubmit} className="flex flex-col gap-5">
-        <Flex direction="flex-col" className="py-5 px-2 overflow-y-auto max-h-[80vh]">
-          <ScheduleFormContent />
-        </Flex>
+    <>
+      <BottomSheet>
+        <BottomSheetHeader title={`커스텀 과목 ${title}`} headerType="close" onClose={handleCancelSchedule} />
+        <form onSubmit={handleSubmit} className="flex flex-col gap-5">
+          <Flex direction="flex-col" className="py-5 px-2 overflow-y-auto max-h-[80vh]">
+            <ScheduleFormContent />
+          </Flex>
 
-        <Flex justify="justify-end" gap={isMobile ? 'gap-2' : 'gap-4'} className="p-4">
-          {(modalActionType === ScheduleMutateType.EDIT || modalActionType === ScheduleMutateType.VIEW) && (
-            <Button variant="secondary" size={isMobile ? 'small' : 'medium'} onClick={deleteSchedule}>
-              삭제
+          <Flex justify="justify-end" gap={isMobile ? 'gap-2' : 'gap-4'} className="p-4">
+            {(modalActionType === ScheduleMutateType.EDIT || modalActionType === ScheduleMutateType.VIEW) && (
+              <Button variant="secondary" size={isMobile ? 'small' : 'medium'} onClick={handleDeleteSchedule}>
+                삭제
+              </Button>
+            )}
+
+            <Button type="submit" variant="primary" size={isMobile ? 'small' : 'medium'}>
+              저장
             </Button>
-          )}
+          </Flex>
+        </form>
+      </BottomSheet>
 
-          <Button type="submit" variant="primary" size={isMobile ? 'small' : 'medium'}>
-            저장
-          </Button>
-        </Flex>
-      </form>
-    </BottomSheet>
+      <ConfirmDialog
+        isOpen={isDeleteOpen}
+        title="커스텀 과목 삭제"
+        description="해당 커스텀 과목을 삭제하시겠습니까?"
+        confirmLabel="삭제"
+        danger
+        onConfirm={handleConfirmDelete}
+        onClose={() => setIsDeleteOpen(false)}
+      />
+    </>
   );
 }
 

--- a/packages/client/src/widgets/bottomSheet/ui/ScheduleFormBottomSheet.tsx
+++ b/packages/client/src/widgets/bottomSheet/ui/ScheduleFormBottomSheet.tsx
@@ -6,10 +6,9 @@ import useMobile from '@/shared/lib/useMobile.ts';
 import BottomSheet from '@/shared/ui/bottomsheet/BottomSheet';
 import BottomSheetHeader from '@/shared/ui/bottomsheet/BottomSheetHeader';
 import ScheduleFormContent from '@/features/timetable/ui/ScheduleFormContent';
-import ConfirmDialog from '@/shared/ui/ConfirmDialog';
 
 function ScheduleFormBottomSheet() {
-  const [isDeleteOpen, setIsDeleteOpen] = useState(false);
+  const [isDeleteConfirming, setIsDeleteConfirming] = useState(false);
   const { modalActionType } = useScheduleModalData();
   const { cancelSchedule, deleteSchedule, saveSchedule } = useScheduleModal();
 
@@ -26,47 +25,64 @@ function ScheduleFormBottomSheet() {
 
   const handleDeleteSchedule = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
-    setIsDeleteOpen(true);
+    setIsDeleteConfirming(true);
+  };
+
+  const handleCancelDeleteConfirmation = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setIsDeleteConfirming(false);
   };
 
   const handleConfirmDelete = () => {
-    setIsDeleteOpen(false);
-    requestAnimationFrame(() => deleteSchedule());
+    deleteSchedule();
   };
 
   return (
-    <>
-      <BottomSheet>
-        <BottomSheetHeader title={`커스텀 일정 ${title}`} headerType="close" onClose={handleCancelSchedule} />
-        <form onSubmit={handleSubmit} className="flex flex-col gap-5">
-          <Flex direction="flex-col" className="py-5 px-2 overflow-y-auto max-h-[80vh]">
-            <ScheduleFormContent />
-          </Flex>
+    <BottomSheet>
+      <BottomSheetHeader title={`커스텀 일정 ${title}`} headerType="close" onClose={handleCancelSchedule} />
+      <form onSubmit={handleSubmit} className="flex flex-col gap-5">
+        <Flex direction="flex-col" className="py-5 px-2 overflow-y-auto max-h-[80vh]">
+          <ScheduleFormContent />
+        </Flex>
 
-          <Flex justify="justify-end" gap={isMobile ? 'gap-2' : 'gap-4'} className="p-4">
-            {(modalActionType === ScheduleMutateType.EDIT || modalActionType === ScheduleMutateType.VIEW) && (
-              <Button variant="secondary" size={isMobile ? 'small' : 'medium'} onClick={handleDeleteSchedule}>
+        <Flex justify="justify-end" align="items-center" gap={isMobile ? 'gap-2' : 'gap-4'} className="p-4">
+          {isDeleteConfirming ? (
+            <>
+              <span className="self-center text-sm text-gray-600">커스텀 일정을 삭제하시겠습니까?</span>
+              <Button
+                type="button"
+                variant="secondary"
+                size={isMobile ? 'small' : 'medium'}
+                onClick={handleCancelDeleteConfirmation}
+              >
+                취소
+              </Button>
+              <Button type="button" variant="danger" size={isMobile ? 'small' : 'medium'} onClick={handleConfirmDelete}>
                 삭제
               </Button>
-            )}
+            </>
+          ) : (
+            <>
+              {(modalActionType === ScheduleMutateType.EDIT || modalActionType === ScheduleMutateType.VIEW) && (
+                <Button
+                  type="button"
+                  variant="secondary"
+                  size={isMobile ? 'small' : 'medium'}
+                  onClick={handleDeleteSchedule}
+                >
+                  삭제
+                </Button>
+              )}
 
-            <Button type="submit" variant="primary" size={isMobile ? 'small' : 'medium'}>
-              저장
-            </Button>
-          </Flex>
-        </form>
-      </BottomSheet>
-
-      <ConfirmDialog
-        isOpen={isDeleteOpen}
-        title="커스텀 일정 삭제"
-        description="해당 커스텀 일정을 삭제하시겠습니까?"
-        confirmLabel="삭제"
-        danger
-        onConfirm={handleConfirmDelete}
-        onClose={() => setIsDeleteOpen(false)}
-      />
-    </>
+              <Button type="submit" variant="primary" size={isMobile ? 'small' : 'medium'}>
+                저장
+              </Button>
+            </>
+          )}
+        </Flex>
+      </form>
+    </BottomSheet>
   );
 }
 

--- a/packages/client/src/widgets/bottomSheet/ui/ScheduleFormBottomSheet.tsx
+++ b/packages/client/src/widgets/bottomSheet/ui/ScheduleFormBottomSheet.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import useScheduleModal, { useScheduleModalData } from '@/features/timetable/lib/useScheduleModal.ts';
 import { ScheduleMutateType } from '@/features/timetable/model/useScheduleState.ts';
 import { Button, Flex } from '@allcll/allcll-ui';
@@ -6,9 +6,10 @@ import useMobile from '@/shared/lib/useMobile.ts';
 import BottomSheet from '@/shared/ui/bottomsheet/BottomSheet';
 import BottomSheetHeader from '@/shared/ui/bottomsheet/BottomSheetHeader';
 import ScheduleFormContent from '@/features/timetable/ui/ScheduleFormContent';
+import DeleteConfirmationActions from '@/features/timetable/ui/DeleteConfirmationActions';
+import useDeleteConfirmation from '@/features/timetable/lib/useDeleteConfirmation';
 
 function ScheduleFormBottomSheet() {
-  const [isDeleteConfirming, setIsDeleteConfirming] = useState(false);
   const { modalActionType } = useScheduleModalData();
   const { cancelSchedule, deleteSchedule, saveSchedule } = useScheduleModal();
 
@@ -18,24 +19,12 @@ function ScheduleFormBottomSheet() {
 
   const title = modalActionType === ScheduleMutateType.CREATE ? '생성' : '수정';
   const isMobile = useMobile();
+  const buttonSize = isMobile ? 'small' : 'medium';
+  const { isDeleteConfirming, requestDeleteConfirmation, cancelDeleteConfirmation, confirmDelete } =
+    useDeleteConfirmation(deleteSchedule);
 
   const handleSubmit = (e: React.FormEvent) => {
     saveSchedule(e);
-  };
-
-  const handleDeleteSchedule = (e: React.MouseEvent<HTMLButtonElement>) => {
-    e.preventDefault();
-    setIsDeleteConfirming(true);
-  };
-
-  const handleCancelDeleteConfirmation = (e: React.MouseEvent<HTMLButtonElement>) => {
-    e.preventDefault();
-    e.stopPropagation();
-    setIsDeleteConfirming(false);
-  };
-
-  const handleConfirmDelete = () => {
-    deleteSchedule();
   };
 
   return (
@@ -48,34 +37,21 @@ function ScheduleFormBottomSheet() {
 
         <Flex justify="justify-end" align="items-center" gap={isMobile ? 'gap-2' : 'gap-4'} className="p-4">
           {isDeleteConfirming ? (
-            <>
-              <span className="self-center text-sm text-gray-600">커스텀 일정을 삭제하시겠습니까?</span>
-              <Button
-                type="button"
-                variant="secondary"
-                size={isMobile ? 'small' : 'medium'}
-                onClick={handleCancelDeleteConfirmation}
-              >
-                취소
-              </Button>
-              <Button type="button" variant="danger" size={isMobile ? 'small' : 'medium'} onClick={handleConfirmDelete}>
-                삭제
-              </Button>
-            </>
+            <DeleteConfirmationActions
+              message="커스텀 일정을 삭제하시겠습니까?"
+              size={buttonSize}
+              onCancel={cancelDeleteConfirmation}
+              onConfirm={confirmDelete}
+            />
           ) : (
             <>
               {(modalActionType === ScheduleMutateType.EDIT || modalActionType === ScheduleMutateType.VIEW) && (
-                <Button
-                  type="button"
-                  variant="secondary"
-                  size={isMobile ? 'small' : 'medium'}
-                  onClick={handleDeleteSchedule}
-                >
+                <Button type="button" variant="secondary" size={buttonSize} onClick={requestDeleteConfirmation}>
                   삭제
                 </Button>
               )}
 
-              <Button type="submit" variant="primary" size={isMobile ? 'small' : 'medium'}>
+              <Button type="submit" variant="primary" size={buttonSize}>
                 저장
               </Button>
             </>

--- a/packages/client/src/widgets/home/ui/TimetableSection.tsx
+++ b/packages/client/src/widgets/home/ui/TimetableSection.tsx
@@ -1,7 +1,7 @@
 import Section from '@/widgets/home/ui/Section.tsx';
 import SectionHeader from '@/widgets/home/ui/SectionHeader.tsx';
 import TimetableGridComponent from '@/widgets/timetable/TimetableGridComponent.tsx';
-import { GeneralSchedule, getScheduleSlots, ScheduleSlot } from '@/entities/timetable/api/useTimetableSchedules.ts';
+import { GeneralSchedule, useScheduleSlots, ScheduleSlot } from '@/entities/timetable/api/useTimetableSchedules.ts';
 import Schedule from '@/widgets/timetable/Schedule.tsx';
 import { Card } from '@allcll/allcll-ui';
 
@@ -54,7 +54,7 @@ const ScheduleData = [
 ] as GeneralSchedule[];
 
 function TimetableSection() {
-  const data = getScheduleSlots(ScheduleData, 9);
+  const data = useScheduleSlots(ScheduleData, 9);
 
   return (
     <Section>

--- a/packages/client/src/widgets/timetable/ScheduleSlotList.tsx
+++ b/packages/client/src/widgets/timetable/ScheduleSlotList.tsx
@@ -1,4 +1,4 @@
-import { getEmptyScheduleSlots, GeneralSchedule } from '@/entities/timetable/api/useTimetableSchedules.ts';
+import { useEmptyScheduleSlots, GeneralSchedule } from '@/entities/timetable/api/useTimetableSchedules.ts';
 import XGraySvg from '@/assets/x-darkgray.svg?react';
 import useScheduleModal from '@/features/timetable/lib/useScheduleModal.ts';
 import { Flex, IconButton } from '@allcll/allcll-ui';
@@ -8,7 +8,7 @@ interface IScheduleSlotList {
 }
 
 function ScheduleSlotList({ schedules }: IScheduleSlotList) {
-  const scheduleSlots = getEmptyScheduleSlots(schedules);
+  const scheduleSlots = useEmptyScheduleSlots(schedules);
 
   return (
     <Flex direction="flex-col" gap="gap-2" className="mt-3">

--- a/packages/client/src/widgets/timetable/TimetableComponent.tsx
+++ b/packages/client/src/widgets/timetable/TimetableComponent.tsx
@@ -3,7 +3,7 @@ import DaySchedule from '@/widgets/timetable/DaySchedule.tsx';
 import TmNumsComponent from '@/widgets/timetable/TmNumsComponent.tsx';
 import ScheduleSlotList from '@/widgets/timetable/ScheduleSlotList.tsx';
 import { useUpdateTimetableOptions } from '@/features/timetable/lib/useUpdateTimetableOptions.ts';
-import { GeneralSchedule, getScheduleSlots, ScheduleSlot } from '@/entities/timetable/api/useTimetableSchedules.ts';
+import { GeneralSchedule, useScheduleSlots, ScheduleSlot } from '@/entities/timetable/api/useTimetableSchedules.ts';
 import { useScheduleState } from '@/features/timetable/model/useScheduleState.ts';
 import useNotifyDeletedSchedule from '@/features/notification/lib/useNotifyDeletedSchedule.ts';
 import TimetableGridComponent from '@/widgets/timetable/TimetableGridComponent.tsx';
@@ -48,7 +48,7 @@ const DefaultScheduleTimes: Record<Day, ScheduleSlot[]> = DAYS.reduce(
 function WeekTable({ schedules }: { schedules: GeneralSchedule[] }) {
   const { colNames, minTime } = useScheduleState(state => state.options);
 
-  const scheduleSlots = getScheduleSlots(schedules, minTime) ?? DefaultScheduleTimes;
+  const scheduleSlots = useScheduleSlots(schedules, minTime) ?? DefaultScheduleTimes;
 
   useNotifyDeletedSchedule(schedules);
   useUpdateTimetableOptions(schedules);

--- a/packages/client/src/widgets/timetable/TimetableSelect.tsx
+++ b/packages/client/src/widgets/timetable/TimetableSelect.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
-import { TimetableType, useDeleteTimetable } from '@/entities/timetable/api/useTimetableSchedules.ts';
+import { useDeleteTimetable } from '@/entities/timetable/api/useTimetableSchedules.ts';
+import type { TimetableType } from '@/entities/timetable/api/useTimetableSchedules.ts';
 import { useScheduleState } from '@/features/timetable/model/useScheduleState.ts';
 import { Button, Checkbox, Flex, Popover, SupportingText, usePopoverContext } from '@allcll/allcll-ui';
 import ConfirmDialog from '@/shared/ui/ConfirmDialog.tsx';

--- a/packages/client/src/widgets/timetable/TimetableSelect.tsx
+++ b/packages/client/src/widgets/timetable/TimetableSelect.tsx
@@ -3,7 +3,10 @@ import { TimetableType, useDeleteTimetable } from '@/entities/timetable/api/useT
 import { useScheduleState } from '@/features/timetable/model/useScheduleState.ts';
 import { Button, Checkbox, Flex, Popover, SupportingText, usePopoverContext } from '@allcll/allcll-ui';
 import ConfirmDialog from '@/shared/ui/ConfirmDialog.tsx';
-import { showTimetableApiErrorToast } from '@/features/timetable/lib/showTimetableApiErrorToast';
+import {
+  showTimetableApiErrorToast,
+  showTimetableApiSuccessToast,
+} from '@/features/timetable/lib/showTimetableApiErrorToast';
 
 function TimetableActions({ onEdit, onDelete }: { onEdit: () => void; onDelete: () => void }) {
   const { close } = usePopoverContext();
@@ -46,7 +49,13 @@ const TimetableSelect = ({ setIsOpenModal, openCreateModal, timetables, currentT
   const [pendingDeleteId, setPendingDeleteId] = useState<number | null>(null);
   const pickTimetable = useScheduleState(state => state.pickTimetable);
 
-  const { mutate: deleteTimetable } = useDeleteTimetable();
+  const { mutate: deleteTimetable } = useDeleteTimetable({
+    onSuccess: () =>
+      showTimetableApiSuccessToast({
+        message: '시간표를 삭제했습니다.',
+        tag: 'timetable-delete-success',
+      }),
+  });
 
   const handleOptionClick = (option: TimetableType) => {
     const selectedTimetable = timetables.find(

--- a/packages/client/src/widgets/timetable/TimetableSelect.tsx
+++ b/packages/client/src/widgets/timetable/TimetableSelect.tsx
@@ -1,5 +1,6 @@
 import { TimetableType, useDeleteTimetable } from '@/entities/timetable/api/useTimetableSchedules.ts';
 import { useScheduleState } from '@/features/timetable/model/useScheduleState.ts';
+import useToastNotification from '@/features/notification/model/useToastNotification.ts';
 import { Button, Checkbox, Flex, Popover, SupportingText } from '@allcll/allcll-ui';
 
 interface TimetableSelectProps {
@@ -29,7 +30,12 @@ const TimetableSelect = ({ setIsOpenModal, openCreateModal, timetables, currentT
   };
 
   const handleTimetableDelete = (optionId: number) => {
-    deleteTimetable(optionId);
+    deleteTimetable(optionId, {
+      onError: () =>
+        useToastNotification
+          .getState()
+          .addToast('시간표 삭제에 실패했습니다. 다시 시도해주세요.', 'timetable-delete-error'),
+    });
   };
 
   if (!currentTimetable && timetables.length === 0) {

--- a/packages/client/src/widgets/timetable/TimetableSelect.tsx
+++ b/packages/client/src/widgets/timetable/TimetableSelect.tsx
@@ -1,7 +1,39 @@
+import { useState } from 'react';
 import { TimetableType, useDeleteTimetable } from '@/entities/timetable/api/useTimetableSchedules.ts';
 import { useScheduleState } from '@/features/timetable/model/useScheduleState.ts';
 import useToastNotification from '@/features/notification/model/useToastNotification.ts';
-import { Button, Checkbox, Flex, Popover, SupportingText } from '@allcll/allcll-ui';
+import { Button, Checkbox, Flex, Popover, SupportingText, usePopoverContext } from '@allcll/allcll-ui';
+import ConfirmDialog from '@/shared/ui/ConfirmDialog.tsx';
+
+function TimetableActions({ onEdit, onDelete }: { onEdit: () => void; onDelete: () => void }) {
+  const { close } = usePopoverContext();
+
+  return (
+    <Flex gap="gap-4">
+      <Button
+        variant="text"
+        size="small"
+        onClick={() => {
+          close();
+          onEdit();
+        }}
+      >
+        수정
+      </Button>
+      <Button
+        variant="text"
+        size="small"
+        textColor="secondary"
+        onClick={() => {
+          close();
+          onDelete();
+        }}
+      >
+        삭제
+      </Button>
+    </Flex>
+  );
+}
 
 interface TimetableSelectProps {
   setIsOpenModal: React.Dispatch<React.SetStateAction<'edit' | 'create' | null>>;
@@ -11,6 +43,7 @@ interface TimetableSelectProps {
 }
 
 const TimetableSelect = ({ setIsOpenModal, openCreateModal, timetables, currentTimetable }: TimetableSelectProps) => {
+  const [pendingDeleteId, setPendingDeleteId] = useState<number | null>(null);
   const pickTimetable = useScheduleState(state => state.pickTimetable);
 
   const { mutate: deleteTimetable } = useDeleteTimetable();
@@ -30,12 +63,18 @@ const TimetableSelect = ({ setIsOpenModal, openCreateModal, timetables, currentT
   };
 
   const handleTimetableDelete = (optionId: number) => {
-    deleteTimetable(optionId, {
+    setPendingDeleteId(optionId);
+  };
+
+  const confirmTimetableDelete = () => {
+    if (pendingDeleteId === null) return;
+    deleteTimetable(pendingDeleteId, {
       onError: () =>
         useToastNotification
           .getState()
           .addToast('시간표 삭제에 실패했습니다. 다시 시도해주세요.', 'timetable-delete-error'),
     });
+    setPendingDeleteId(null);
   };
 
   if (!currentTimetable && timetables.length === 0) {
@@ -47,46 +86,49 @@ const TimetableSelect = ({ setIsOpenModal, openCreateModal, timetables, currentT
   }
 
   return (
-    <Popover>
-      <Popover.Trigger label={currentTimetable ? currentTimetable.timeTableName : '새 시간표'} />
+    <>
+      <Popover>
+        <Popover.Trigger label={currentTimetable ? currentTimetable.timeTableName : '새 시간표'} />
 
-      <Popover.Content>
-        <Flex direction="flex-col" gap="gap-4">
-          {timetables.length === 0 && <SupportingText>새로운 시간표를 추가해주세요.</SupportingText>}
-          {timetables.map(option => (
-            <Flex gap="gap-4" key={option.timeTableName + option.timeTableId}>
-              <Checkbox
-                key={option.timeTableId}
-                label={option.timeTableName}
-                checked={currentTimetable?.timeTableId === option.timeTableId}
-                onChange={() => handleOptionClick(option)}
-              />
-              {currentTimetable?.timeTableId === option.timeTableId && (
-                <Flex gap="gap-4">
-                  <Button variant="text" size="small" onClick={handleTimetableEdit}>
-                    수정
-                  </Button>
-                  <Button
-                    variant="text"
-                    size="small"
-                    textColor="secondary"
-                    onClick={() => handleTimetableDelete(option.timeTableId)}
-                  >
-                    삭제
-                  </Button>
-                </Flex>
-              )}
-            </Flex>
-          ))}
+        <Popover.Content>
+          <Flex direction="flex-col" gap="gap-4">
+            {timetables.length === 0 && <SupportingText>새로운 시간표를 추가해주세요.</SupportingText>}
+            {timetables.map(option => (
+              <Flex gap="gap-4" key={option.timeTableName + option.timeTableId}>
+                <Checkbox
+                  key={option.timeTableId}
+                  label={option.timeTableName}
+                  checked={currentTimetable?.timeTableId === option.timeTableId}
+                  onChange={() => handleOptionClick(option)}
+                />
+                {currentTimetable?.timeTableId === option.timeTableId && (
+                  <TimetableActions
+                    onEdit={handleTimetableEdit}
+                    onDelete={() => handleTimetableDelete(option.timeTableId)}
+                  />
+                )}
+              </Flex>
+            ))}
 
-          {currentTimetable && (
-            <Button variant="text" size="small" textColor="gray" onClick={openCreateModal}>
-              + 시간표 추가하기
-            </Button>
-          )}
-        </Flex>
-      </Popover.Content>
-    </Popover>
+            {currentTimetable && (
+              <Button variant="text" size="small" textColor="gray" onClick={openCreateModal}>
+                + 시간표 추가하기
+              </Button>
+            )}
+          </Flex>
+        </Popover.Content>
+      </Popover>
+
+      <ConfirmDialog
+        isOpen={pendingDeleteId !== null}
+        title="시간표 삭제"
+        description="시간표를 삭제하시겠습니까?"
+        confirmLabel="삭제"
+        danger
+        onConfirm={confirmTimetableDelete}
+        onClose={() => setPendingDeleteId(null)}
+      />
+    </>
   );
 };
 

--- a/packages/client/src/widgets/timetable/TimetableSelect.tsx
+++ b/packages/client/src/widgets/timetable/TimetableSelect.tsx
@@ -1,9 +1,9 @@
 import { useState } from 'react';
 import { TimetableType, useDeleteTimetable } from '@/entities/timetable/api/useTimetableSchedules.ts';
 import { useScheduleState } from '@/features/timetable/model/useScheduleState.ts';
-import useToastNotification from '@/features/notification/model/useToastNotification.ts';
 import { Button, Checkbox, Flex, Popover, SupportingText, usePopoverContext } from '@allcll/allcll-ui';
 import ConfirmDialog from '@/shared/ui/ConfirmDialog.tsx';
+import { showTimetableApiErrorToast } from '@/features/timetable/lib/showTimetableApiErrorToast';
 
 function TimetableActions({ onEdit, onDelete }: { onEdit: () => void; onDelete: () => void }) {
   const { close } = usePopoverContext();
@@ -69,10 +69,11 @@ const TimetableSelect = ({ setIsOpenModal, openCreateModal, timetables, currentT
   const confirmTimetableDelete = () => {
     if (pendingDeleteId === null) return;
     deleteTimetable(pendingDeleteId, {
-      onError: () =>
-        useToastNotification
-          .getState()
-          .addToast('시간표 삭제에 실패했습니다. 다시 시도해주세요.', 'timetable-delete-error'),
+      onError: error =>
+        showTimetableApiErrorToast(error, {
+          fallbackMessage: '시간표 삭제에 실패했습니다. 다시 시도해주세요.',
+          tag: 'timetable-delete-error',
+        }),
     });
     setPendingDeleteId(null);
   };


### PR DESCRIPTION
## 작업 내용
* 기존 alert 기반 오류 메시지를 토스트 기반으로 교체했습니다.
* 시간표 수정 시 기존 이름이 불러와지지 않는 현상을 수정했습니다.
* 토스트가 모달 overlay 아래에 표시되던 현상을 수정했습니다.
* 시간표에 이미 추가된 과목 재추가 시 중복 방지 처리를 추가했습니다.
* ConfirmDialog 공통 컴포넌트를 추가하여 기존 `confirm()` 로직을 대체했습니다.
* `EditTimetable.tsx`에 중복 정의되어 있던 삭제 버튼을 제거했습니다.

## 변경 사항 및 리뷰 포인트
`getEmptyScheduleSlots` -> `useEmptyScheduleSlots`, `getScheduleSlots` -> `useScheduleSlots` 네이밍 변경의 경우 lint 단계에서 걸려서 부득이하게 수정했습니다.

노션에 정리된 내용 중에서 일단 제가 재현 가능한 사항들만 수정해보았는데, 혹시나 빠진 부분이 있다면 말씀해주세요!