### PR TITLE
fix: 공지 상세 제목 위치 및 모바일 헤더 레이아웃 개선

### DIFF
--- a/packages/client/src/features/notices/ui/NoticeDetailModal.tsx
+++ b/packages/client/src/features/notices/ui/NoticeDetailModal.tsx
@@ -31,20 +31,22 @@ function NoticeDetailModal({ notice, onClose }: Readonly<NoticeDetailModalProps>
         aria-labelledby="notice-detail-title"
         className="relative z-10 bg-white rounded-xl shadow-xl w-full max-w-3xl max-h-[80vh] flex flex-col overflow-hidden"
       >
-        <Flex align="items-center" justify="justify-between" className="px-5 py-4 border-b border-gray-100">
+        <Flex direction="flex-col" gap="gap-2" className="px-5 py-4 border-b border-gray-100">
+          <Flex align="items-start" justify="justify-between" gap="gap-3">
+            <h2 id="notice-detail-title" className="text-base font-semibold text-gray-900">
+              {notice.title}
+            </h2>
+            <IconButton variant="plain" label="닫기" icon={<CloseSvg className="w-4 h-4" />} onClick={onClose} />
+          </Flex>
           <Flex align="items-center" gap="gap-2">
             <Badge variant="primary" size="small">
               {getNoticeLabel(notice.operationType)}
             </Badge>
             <span className="text-xs text-gray-400">{date}</span>
           </Flex>
-          <IconButton variant="plain" label="닫기" icon={<CloseSvg className="w-4 h-4" />} onClick={onClose} />
         </Flex>
 
         <div className="px-5 py-4 overflow-y-auto">
-          <h2 id="notice-detail-title" className="text-base font-semibold text-gray-900 mb-4">
-            {notice.title}
-          </h2>
           <div className="prose max-w-none">
             <ReactMarkdown remarkPlugins={[remarkGfm, remarkBreaks]}>{notice.content}</ReactMarkdown>
           </div>

--- a/packages/client/src/features/notices/ui/NoticeDetailModal.tsx
+++ b/packages/client/src/features/notices/ui/NoticeDetailModal.tsx
@@ -2,7 +2,7 @@ import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import remarkBreaks from 'remark-breaks';
 import { createPortal } from 'react-dom';
-import { Badge, Flex, IconButton } from '@allcll/allcll-ui';
+import { Badge, Flex, Heading, IconButton } from '@allcll/allcll-ui';
 import CloseSvg from '@/assets/x.svg?react';
 import { type Notice, getNoticeLabel } from '@/entities/notices/model/notice';
 
@@ -33,9 +33,9 @@ function NoticeDetailModal({ notice, onClose }: Readonly<NoticeDetailModalProps>
       >
         <Flex direction="flex-col" gap="gap-2" className="px-5 py-4 border-b border-gray-100">
           <Flex align="items-start" justify="justify-between" gap="gap-3">
-            <h2 id="notice-detail-title" className="text-base font-semibold text-gray-900">
+            <Heading level={2} size="lg" id="notice-detail-title" className="text-gray-900">
               {notice.title}
-            </h2>
+            </Heading>
             <IconButton variant="plain" label="닫기" icon={<CloseSvg className="w-4 h-4" />} onClick={onClose} />
           </Flex>
           <Flex align="items-center" gap="gap-2">

--- a/packages/client/src/features/notices/ui/NoticePanel.tsx
+++ b/packages/client/src/features/notices/ui/NoticePanel.tsx
@@ -28,12 +28,18 @@ function NoticePanel({ notices, isMobile = false, isRead, onRead, onClose }: Rea
   if (isMobile && selectedNotice) {
     return (
       <Flex direction="flex-col" className="h-full">
-        <Flex align="items-center" justify="justify-between" className="px-4 py-3 border-b border-gray-100">
-          <Button variant="text" size="small" textColor="gray" onClick={() => setSelectedNotice(null)}>
+        <Flex align="items-center" justify="justify-between" className="p-4 border-b border-gray-100">
+          <Button variant="text" size="medium" textColor="gray" onClick={() => setSelectedNotice(null)}>
             <ChevronLeftSvg className="w-4 h-4" />
             목록
           </Button>
-          <IconButton variant="plain" label="닫기" icon={<CloseSvg className="w-4 h-4" />} onClick={onClose} />
+          <IconButton
+            className="p-2 hover:bg-gray-100 active:bg-gray-100"
+            variant="plain"
+            label="닫기"
+            icon={<CloseSvg className="w-6 h-6" />}
+            onClick={onClose}
+          />
         </Flex>
 
         <div className="flex-1 overflow-y-auto px-5 py-4 flex flex-col gap-3">
@@ -54,9 +60,15 @@ function NoticePanel({ notices, isMobile = false, isRead, onRead, onClose }: Rea
 
   return (
     <Flex direction="flex-col" className="h-full">
-      <Flex align="items-center" justify="justify-between" className="px-4 py-3 border-b border-gray-100">
-        <span className="text-sm font-semibold text-gray-900">공지사항</span>
-        <IconButton variant="plain" label="닫기" icon={<CloseSvg className="w-4 h-4" />} onClick={onClose} />
+      <Flex align="items-center" justify="justify-between" className="p-4 border-b border-gray-100">
+        <span className="text-base font-semibold text-gray-900">공지사항</span>
+        <IconButton
+          className="p-2 hover:bg-gray-100 active:bg-gray-100"
+          variant="plain"
+          label="닫기"
+          icon={<CloseSvg className="w-6 h-6" />}
+          onClick={onClose}
+        />
       </Flex>
 
       <div className="flex-1 overflow-y-auto divide-y divide-gray-100">

--- a/packages/client/src/features/notices/ui/NoticePanel.tsx
+++ b/packages/client/src/features/notices/ui/NoticePanel.tsx
@@ -37,13 +37,13 @@ function NoticePanel({ notices, isMobile = false, isRead, onRead, onClose }: Rea
         </Flex>
 
         <div className="flex-1 overflow-y-auto px-5 py-4 flex flex-col gap-3">
+          <h2 className="text-base font-semibold text-gray-900">{selectedNotice.title}</h2>
           <Flex align="items-center" gap="gap-2">
             <Badge variant="primary" size="small">
               {getNoticeLabel(selectedNotice.operationType)}
             </Badge>
             <span className="text-xs text-gray-400">{selectedNotice.createdAt.slice(0, 10).replace(/-/g, '.')}</span>
           </Flex>
-          <h2 className="text-base font-semibold text-gray-900">{selectedNotice.title}</h2>
           <div className="prose max-w-none">
             <ReactMarkdown remarkPlugins={[remarkGfm, remarkBreaks]}>{selectedNotice.content}</ReactMarkdown>
           </div>

--- a/packages/client/src/features/notices/ui/NoticePanel.tsx
+++ b/packages/client/src/features/notices/ui/NoticePanel.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import remarkBreaks from 'remark-breaks';
-import { Badge, Button, Flex, IconButton } from '@allcll/allcll-ui';
+import { Badge, Button, Flex, Heading, IconButton } from '@allcll/allcll-ui';
 import CloseSvg from '@/assets/x.svg?react';
 import ChevronLeftSvg from '@/assets/chevron-left.svg?react';
 import { type Notice, getNoticeLabel } from '@/entities/notices/model/notice';
@@ -43,7 +43,9 @@ function NoticePanel({ notices, isMobile = false, isRead, onRead, onClose }: Rea
         </Flex>
 
         <div className="flex-1 overflow-y-auto px-5 py-4 flex flex-col gap-3">
-          <h2 className="text-base font-semibold text-gray-900">{selectedNotice.title}</h2>
+          <Heading level={2} size="lg" className="text-gray-900">
+            {selectedNotice.title}
+          </Heading>
           <Flex align="items-center" gap="gap-2">
             <Badge variant="primary" size="small">
               {getNoticeLabel(selectedNotice.operationType)}


### PR DESCRIPTION
## 작업 내용
[QA 피드백](https://discord.com/channels/1336227271106625609/1398290107714240512/1504096050233868319)을 반영하여 공지 상세 뷰의 제목 위치를 변경했습니다.

- 기존: 뱃지·날짜가 위, 제목이 아래
- 변경: 제목이 위, 뱃지·날짜가 아래

추가적으로 모바일에서 공지 패널과 햄버거 메뉴를 비교했을 때 헤더 부분이 달라 어색했던 부분도 함께 통일했습니다.

| 웹 | 모바일 |
| --- | --- |
| <img width="2514" height="1320" alt="image" src="https://github.com/user-attachments/assets/359bcde7-05ee-4ef1-ad6d-7c25674578fc" /> | <img width="646" height="1140" alt="image" src="https://github.com/user-attachments/assets/fdbf837f-23f3-4c3f-8ea9-38bd58c74740" /> |

## 변경 사항 및 리뷰 포인트
- 데스크탑 공지 모달: 제목을 헤더 맨 위로 옮기고, 뱃지·날짜는 그 아래로 이동
- 모바일 공지 상세 화면: 뱃지·날짜보다 제목이 위에 오도록 순서 변경
- 모바일 공지 패널 헤더: 햄버거 메뉴와 패딩, X 버튼 사이즈를 통일
- 시각적 균형을 위해 "공지사항" 타이틀과 "← 목록" 버튼 크기도 X 버튼에 맞춰 조정