### PR TITLE
hotfix: live 전광판 정렬 안되는 버그 수정

### DIFF
--- a/packages/client/src/widgets/live/board/ui/RealtimeTable.tsx
+++ b/packages/client/src/widgets/live/board/ui/RealtimeTable.tsx
@@ -135,8 +135,8 @@ function SubjectBody({ tableTitles }: Readonly<{ tableTitles: HeadTitle<SseSubje
   return (
     <TransitionGroup component={null}>
       {tableData.map(subject => (
-        <CSSTransition key={subject.code} timeout={500} classNames="row-change">
-          <SubjectRow key={subject.code} subject={subject} HeadTitles={HeadTitles} />
+        <CSSTransition key={subject.subjectId} timeout={500} classNames="row-change">
+          <SubjectRow key={subject.subjectId} subject={subject} HeadTitles={HeadTitles} />
         </CSSTransition>
       ))}
     </TransitionGroup>
@@ -165,7 +165,8 @@ function SubjectRow({ subject, HeadTitles }: Readonly<{ subject: SseSubject; Hea
     <tr
       className={`border-t border-gray-200 text-black transition-colors duration-500 text-nowrap ${bgColor}`}
       data-testid="crawl-row"
-      data-crawled-at={crawledAt}>
+      data-crawled-at={crawledAt}
+    >
       {HeadTitles.map(({ key }) => {
         switch (key) {
           case 'seat':


### PR DESCRIPTION
## 작업 내용
- transition 과, table 을 구성하는 td 의 key 가 subject.code 로 되어있었습니다.
- 같은 학수번호 + 분반이 있을 때는 key 가 중복되어 삭제 및 변경 시 예기치 않은 동작이 발생할 수 있습니다.

## 변경 사항 및 리뷰 포인트
- css transition key 를 subject.code 에서 subject.subjectId로 수정 (key 중복)
