### PR TITLE
refactor: z-index 관리 중앙화

### DIFF
--- a/packages/admin/src/components/Header.tsx
+++ b/packages/admin/src/components/Header.tsx
@@ -4,7 +4,7 @@ const isDevelopment = import.meta.env.VITE_DEV_SERVER === 'true';
 
 function Header() {
   return (
-    <header className="bg-white shadow-xs p-4 z-50 sticky top-0">
+    <header className="bg-white shadow-xs p-4 z-header sticky top-0">
       <div className="container flex items-center justify-between mx-auto max-w-7xl px-4 md:px-16">
         <Heading level={2}>올클 관리자 </Heading>
         <span className="text-sm font-semibold">{isDevelopment ? '개발모드' : 'Prod모드'} </span>

--- a/packages/admin/src/components/notices/NoticeTable.tsx
+++ b/packages/admin/src/components/notices/NoticeTable.tsx
@@ -19,7 +19,7 @@ function NoticeTable({ notices, isLoading, isError, onView, onEdit, onDelete }: 
     <Card className="overflow-hidden flex flex-col flex-1 min-h-0">
       <div className="overflow-y-auto flex-1">
         <table className="w-full border-collapse table-fixed">
-          <thead className="sticky top-0 z-10">
+          <thead className="sticky top-0 z-content">
             <tr className="bg-gray-50 text-sm text-gray-500">
               <th className="text-left px-4 py-2 font-medium w-28">카테고리</th>
               <th className="text-left px-4 py-2 font-medium">제목</th>

--- a/packages/admin/src/components/reviews/ReviewList.tsx
+++ b/packages/admin/src/components/reviews/ReviewList.tsx
@@ -20,7 +20,7 @@ function ReviewList({ reviews, isLoading, isError, filterBar }: Readonly<ReviewL
       <Card className="overflow-hidden flex flex-col flex-1 min-h-0">
         <div className="overflow-y-auto flex-1">
           <table className="w-full border-collapse table-fixed">
-            <thead className="sticky top-0 z-10">
+            <thead className="sticky top-0 z-content">
               <tr className="bg-gray-50 text-sm text-gray-500">
                 <th className="text-left px-4 py-2 font-medium w-28">학번</th>
                 <th className="text-left px-4 py-2 font-medium w-32">도메인</th>

--- a/packages/admin/tailwind.config.ts
+++ b/packages/admin/tailwind.config.ts
@@ -1,5 +1,6 @@
 import { Config } from 'tailwindcss';
 import { colors } from '@allcll/allcll-ui/colors';
+import { Z_INDEX } from '@allcll/allcll-ui/zIndex';
 
 /** @type {import('tailwindcss').Config} */
 const config: Config = {
@@ -11,6 +12,8 @@ const config: Config = {
   ],
   theme: {
     extend: {
+      // z-index 단일 관리: @allcll/allcll-ui/zIndex (z-content, z-modal 등 생성)
+      zIndex: Object.fromEntries(Object.entries(Z_INDEX).map(([key, value]) => [key, String(value)])),
       colors: {
         primary: colors.primary,
         secondary: colors.secondary,

--- a/packages/allcll-ui/src/components/dialog/DialogOverlay.tsx
+++ b/packages/allcll-ui/src/components/dialog/DialogOverlay.tsx
@@ -15,7 +15,7 @@ function DialogOverlay({ children, onClose }: IDialogOverlay) {
 
   return (
     <div
-      className="fixed inset-0 flex items-center bg-transparent justify-center z-300"
+      className="fixed inset-0 flex items-center bg-transparent justify-center z-dialog"
       role="none"
       ref={containerRef}
       onClick={handleBackdropClick}

--- a/packages/allcll-ui/src/components/popover/popover-content/PopoverContent.tsx
+++ b/packages/allcll-ui/src/components/popover/popover-content/PopoverContent.tsx
@@ -2,6 +2,7 @@ import { useRef } from 'react';
 import { createPortal } from 'react-dom';
 import { usePopoverContext } from '../popover/Popover';
 import useDetectClose from '../../../hooks/useDetectClose';
+import { Z_INDEX } from '../../../../zIndex';
 
 function PopoverContent({ children }: { children: React.ReactNode }) {
   const { isOpen, close, open, triggerRef } = usePopoverContext();
@@ -32,7 +33,7 @@ function PopoverContent({ children }: { children: React.ReactNode }) {
         }
       `}
       style={{
-        zIndex: 120,
+        zIndex: Z_INDEX.popover,
         top: rect.bottom + 8,
         left: rect.left,
       }}

--- a/packages/allcll-ui/tailwind.config.ts
+++ b/packages/allcll-ui/tailwind.config.ts
@@ -1,39 +1,19 @@
 import type { Config } from 'tailwindcss';
+import { Z_INDEX } from './zIndex';
+import { colors } from './colors';
 
 /** @type {import('tailwindcss').Config} */
 const config: Config = {
   content: ['./src/**/*.{html,js,jsx,ts,tsx}'],
   theme: {
     extend: {
+      // z-index 단일 관리: ./zIndex.ts (z-content, z-modal 등 생성)
+      zIndex: Object.fromEntries(Object.entries(Z_INDEX).map(([key, value]) => [key, String(value)])),
+      // colors 단일 관리: ./colors.ts (기존 인라인 중복 제거)
       colors: {
-        primary: {
-          50: '#EFF6FF',
-          100: '#DBEAFE',
-          200: '#BFDBFE',
-          300: '#93C5FD',
-          400: '#60A5FA',
-          500: '#3B82F6',
-          600: '#2563EB',
-          700: '#1D4ED8',
-          800: '#1E40AF',
-          900: '#1E3A8A',
-        },
-        secondary: {
-          50: '#FEF2F2',
-          100: '#FEE2E2',
-          200: '#FECACA',
-          300: '#FCA5A5',
-          400: '#F87171',
-          500: '#EF4444',
-          600: '#DC2626',
-          700: '#B91C1C',
-          800: '#991B1B',
-          900: '#7F1D1D',
-        },
-        text: {
-          100: '#1B1B1B',
-          200: '#202123',
-        },
+        primary: colors.primary,
+        secondary: colors.secondary,
+        text: colors.text,
       },
     },
   },

--- a/packages/allcll-ui/zIndex.ts
+++ b/packages/allcll-ui/zIndex.ts
@@ -1,0 +1,39 @@
+/**
+ * z-index 단일 관리 지점 (single source of truth)
+ *
+ * 앱 전역의 쌓임 순서(stacking order)를 이 스케일 하나로 관리합니다.
+ * colors 토큰과 동일하게 디자인 시스템(allcll-ui)에 두고 각 패키지가 공유합니다.
+ *
+ * - Tailwind 클래스로 쓸 때: `z-content`, `z-modal` 처럼 `z-<key>` 사용
+ *   (각 패키지 tailwind.config.ts 의 theme.extend.zIndex 에 주입됩니다)
+ * - inline style 이 불가피할 때: `style={{ zIndex: Z_INDEX.floating }}` 처럼 값 참조
+ *
+ * 새 레이어가 필요하면 반드시 여기에 추가한 뒤 사용하세요.
+ * 컴포넌트에 z-[123] 같은 매직 넘버를 직접 선언하지 않습니다.
+ */
+export const Z_INDEX = {
+  /** 기본 흐름 위로 살짝 띄우는 콘텐츠: sticky 테이블 헤더, 툴팁, 그라데이션 마스크, 사이드바, 그리드, 흐름 내 드롭다운 목록 */
+  content: 10,
+  /** 인라인 로딩 스피너 오버레이 */
+  loading: 12,
+  /** 강조되는 흐름 내 콘텐츠: 메인 배너, 활성/hover 된 시간표 셀 */
+  elevated: 20,
+  /** 메뉴·드로어 뒤를 덮는 전체 화면 딤 배경(backdrop) */
+  overlay: 40,
+  /** 상단 고정 헤더 */
+  header: 50,
+  /** 페이지 위에 떠 있는 UI: 드롭다운 패널, 드로어 본체, FAB, 피드백 버튼, 드래그 중 항목 */
+  floating: 50,
+  /** 앱 자체 중앙 모달 (예: 시뮬레이션 모달) */
+  modal: 100,
+  /** 트리거에 앵커된 팝오버 (모달 위, 바텀 시트 아래) */
+  popover: 120,
+  /** 바텀 시트 / 전체 화면 상세 모달 */
+  bottomSheet: 200,
+  /** 디자인 시스템 Dialog 컴포넌트 (최상위 모달, 바텀 시트 위) */
+  dialog: 300,
+  /** 토스트 알림 (최상단) */
+  toast: 400,
+} as const;
+
+export type ZIndexLayer = keyof typeof Z_INDEX;

--- a/packages/client/src/features/feedback/ui/FeedbackDesktopModal.tsx
+++ b/packages/client/src/features/feedback/ui/FeedbackDesktopModal.tsx
@@ -30,7 +30,7 @@ export default function FeedbackDesktopModal({
   titles,
 }: FeedbackDesktopModalProps) {
   return (
-    <div className="fixed bottom-6 right-6 z-50">
+    <div className="fixed bottom-6 right-6 z-floating">
       <div className="w-80 bg-white rounded-2xl shadow-lg">
         {!success ? (
           <>
@@ -41,7 +41,14 @@ export default function FeedbackDesktopModal({
             </Dialog.Header>
 
             <Dialog.Content>
-              <FeedbackFields titles={titles} rate={rate} setRate={setRate} detail={detail} setDetail={setDetail} error={error} />
+              <FeedbackFields
+                titles={titles}
+                rate={rate}
+                setRate={setRate}
+                detail={detail}
+                setDetail={setDetail}
+                error={error}
+              />
             </Dialog.Content>
 
             <Dialog.Footer>

--- a/packages/client/src/features/feedback/ui/FeedbackPeekBar.tsx
+++ b/packages/client/src/features/feedback/ui/FeedbackPeekBar.tsx
@@ -7,7 +7,7 @@ type Props = {
 
 export default function FeedbackPeekBar({ onOpen, onClose }: Props) {
   return (
-    <div className="fixed bottom-4 left-4 right-4 z-40">
+    <div className="fixed bottom-4 left-4 right-4 z-overlay">
       <div className="rounded-xl bg-white shadow-md border border-gray-100 px-3 py-2">
         <Flex justify="justify-between" align="items-center" className="gap-2">
           <SupportingText className="text-sm">졸업요건 분석 결과, 어떠셨나요?</SupportingText>

--- a/packages/client/src/features/graduation/ui/setup/BasicInfoForm.tsx
+++ b/packages/client/src/features/graduation/ui/setup/BasicInfoForm.tsx
@@ -153,7 +153,7 @@ const BasicInfoForm = ({ nextStep, prevStep, isDepartmentNotFound }: BasicInfoFo
                 />
 
                 {isPrimarySearchOpen && (
-                  <div className="absolute z-10 w-full mt-1 bg-white border border-gray-200 rounded-md shadow-lg max-h-60 overflow-auto">
+                  <div className="absolute z-content w-full mt-1 bg-white border border-gray-200 rounded-md shadow-lg max-h-60 overflow-auto">
                     {filteredPrimaryDepartments && filteredPrimaryDepartments.length > 0 ? (
                       filteredPrimaryDepartments.map(department => {
                         const departmentName = department.departmentName || '학과 정보 없음';
@@ -206,7 +206,7 @@ const BasicInfoForm = ({ nextStep, prevStep, isDepartmentNotFound }: BasicInfoFo
                 />
 
                 {isSearchOpen && (
-                  <div className="absolute z-10 w-full mt-1 bg-white border border-gray-200 rounded-md shadow-lg max-h-60 overflow-auto">
+                  <div className="absolute z-content w-full mt-1 bg-white border border-gray-200 rounded-md shadow-lg max-h-60 overflow-auto">
                     {filteredDoubleDepartments && filteredDoubleDepartments.length > 0 ? (
                       filteredDoubleDepartments.map(department => {
                         const departmentName = department.departmentName || '학과 정보 없음';

--- a/packages/client/src/features/notices/ui/NoticeDetailModal.tsx
+++ b/packages/client/src/features/notices/ui/NoticeDetailModal.tsx
@@ -16,7 +16,7 @@ function NoticeDetailModal({ notice, onClose }: Readonly<NoticeDetailModalProps>
 
   return createPortal(
     <div
-      className="fixed inset-0 z-200 flex items-center justify-center px-4"
+      className="fixed inset-0 z-bottomSheet flex items-center justify-center px-4"
       onMouseDown={e => e.nativeEvent.stopImmediatePropagation()}
     >
       <button
@@ -29,7 +29,7 @@ function NoticeDetailModal({ notice, onClose }: Readonly<NoticeDetailModalProps>
         role="dialog"
         aria-modal="true"
         aria-labelledby="notice-detail-title"
-        className="relative z-10 bg-white rounded-xl shadow-xl w-full max-w-3xl max-h-[80vh] flex flex-col overflow-hidden"
+        className="relative z-content bg-white rounded-xl shadow-xl w-full max-w-3xl max-h-[80vh] flex flex-col overflow-hidden"
       >
         <Flex direction="flex-col" gap="gap-2" className="px-5 py-4 border-b border-gray-100">
           <Flex align="items-start" justify="justify-between" gap="gap-3">

--- a/packages/client/src/features/notices/ui/NoticeDropdown.tsx
+++ b/packages/client/src/features/notices/ui/NoticeDropdown.tsx
@@ -38,7 +38,7 @@ function NoticeDropdown({ notices, isOpen, triggerRef, isRead, onRead, onClose }
   return createPortal(
     <div
       ref={panelRef}
-      className="fixed w-120 h-120 bg-white rounded-xl shadow-xl border border-gray-100 flex flex-col z-50"
+      className="fixed w-120 h-120 bg-white rounded-xl shadow-xl border border-gray-100 flex flex-col z-floating"
       style={{
         top: rect.bottom + 8,
         right: window.innerWidth - rect.right,

--- a/packages/client/src/features/notices/ui/NoticeMobileView.tsx
+++ b/packages/client/src/features/notices/ui/NoticeMobileView.tsx
@@ -23,7 +23,7 @@ function NoticeMobileView({ notices, isOpen, isRead, onRead, onClose }: Readonly
       <CSSTransition in={isOpen} timeout={300} classNames="mobile-menu-overlay" unmountOnExit nodeRef={overlayRef}>
         <div
           ref={overlayRef}
-          className="fixed inset-0 z-40 md:hidden bg-black/30"
+          className="fixed inset-0 z-overlay md:hidden bg-black/30"
           aria-hidden="true"
           onClick={onClose}
         />
@@ -35,7 +35,7 @@ function NoticeMobileView({ notices, isOpen, isRead, onRead, onClose }: Readonly
           role="dialog"
           aria-modal="true"
           aria-label="공지사항"
-          className="fixed top-0 right-0 h-full w-full bg-white shadow-lg z-50 md:hidden flex flex-col"
+          className="fixed top-0 right-0 h-full w-full bg-white shadow-lg z-floating md:hidden flex flex-col"
         >
           <NoticePanel notices={notices} isMobile isRead={isRead} onRead={onRead} onClose={onClose} />
         </div>

--- a/packages/client/src/features/notification/ui/ToastNotification.tsx
+++ b/packages/client/src/features/notification/ui/ToastNotification.tsx
@@ -20,7 +20,7 @@ function ToastNotification() {
 
   return createPortal(
     <div ref={popoverRef} popover="manual" className="toast-popover-root">
-      <div className="fixed top-2 right-2 z-400 max-w-screen">
+      <div className="fixed top-2 right-2 z-toast max-w-screen">
         <TransitionGroup className="flex gap-2 flex-col-reverse">
           {messages.slice(-3).map(message => (
             <CSSTransition key={message.id} timeout={300} classNames="toast">

--- a/packages/client/src/shared/ui/DraggableList.tsx
+++ b/packages/client/src/shared/ui/DraggableList.tsx
@@ -1,6 +1,7 @@
 import React, { useRef, useState, useEffect, useMemo } from 'react';
 import EyeGray from '@/assets/eye-gray.svg?react';
 import EyeDeleteGray from '@/assets/eye-delete-gray.svg?react';
+import { Z_INDEX } from '@allcll/allcll-ui/zIndex';
 
 interface Item {
   title: string; // Assuming title is unique
@@ -137,7 +138,7 @@ export default function DraggableList<T extends Item>({ initialItems, onChange }
       left: rect.left,
       top: rect.top,
       position: 'fixed',
-      zIndex: 50,
+      zIndex: Z_INDEX.floating,
       pointerEvents: 'none',
       transition: 'none',
     });
@@ -164,7 +165,7 @@ export default function DraggableList<T extends Item>({ initialItems, onChange }
     if (hoverIndex === -1) hoverIndex = items.length;
 
     const fromIndex = dragMetaRef.current.currentIndex;
-    let toIndex = Math.max(0, Math.min(items.length - 1, hoverIndex > fromIndex ? hoverIndex - 1 : hoverIndex));
+    const toIndex = Math.max(0, Math.min(items.length - 1, hoverIndex > fromIndex ? hoverIndex - 1 : hoverIndex));
 
     if (toIndex !== fromIndex) {
       dragMetaRef.current.currentIndex = toIndex;

--- a/packages/client/src/shared/ui/Header.tsx
+++ b/packages/client/src/shared/ui/Header.tsx
@@ -38,7 +38,7 @@ function Header() {
   const closeMenu = useCallback(() => setIsOpen(false), []);
 
   return (
-    <header className="bg-white shadow-sm z-50 sticky top-0">
+    <header className="bg-white shadow-sm z-header sticky top-0">
       <div className="container flex items-center justify-between mx-auto max-w-7xl px-4 md:px-16">
         <div className="flex items-center space-x-4 py-4">
           <Link to="/" className="flex items-center gap-1 space-x-2" aria-label="메인 페이지">

--- a/packages/client/src/shared/ui/LoadingSpinner.tsx
+++ b/packages/client/src/shared/ui/LoadingSpinner.tsx
@@ -3,7 +3,7 @@ import { ClipLoader } from 'react-spinners';
 
 function LoadingLayout({ children }: { children: React.ReactNode }) {
   return (
-    <div className="w-screen h-screen fixed top-0 left-0 flex items-center justify-center z-[12] bg-[rgba(93,92,92,0.05)]">
+    <div className="w-screen h-screen fixed top-0 left-0 flex items-center justify-center z-loading bg-[rgba(93,92,92,0.05)]">
       {children}
     </div>
   );

--- a/packages/client/src/shared/ui/MobileMenu.tsx
+++ b/packages/client/src/shared/ui/MobileMenu.tsx
@@ -38,7 +38,7 @@ function MobileMenu({ isOpen, onClose }: Readonly<MobileMenuProps>) {
   return (
     <>
       <CSSTransition in={isOpen} timeout={300} classNames="mobile-menu-overlay" unmountOnExit nodeRef={overlayRef}>
-        <div ref={overlayRef} className="fixed inset-0 z-40 md:hidden bg-black/30" aria-hidden="true" />
+        <div ref={overlayRef} className="fixed inset-0 z-overlay md:hidden bg-black/30" aria-hidden="true" />
       </CSSTransition>
 
       <CSSTransition
@@ -55,7 +55,7 @@ function MobileMenu({ isOpen, onClose }: Readonly<MobileMenuProps>) {
           aria-modal="true"
           aria-labelledby="mobile-menu-title"
           tabIndex={-1}
-          className="fixed top-0 right-0 h-full w-full bg-white shadow-lg z-50 md:hidden flex flex-col"
+          className="fixed top-0 right-0 h-full w-full bg-white shadow-lg z-floating md:hidden flex flex-col"
         >
           <h2 id="mobile-menu-title" className="sr-only">
             모바일 메뉴

--- a/packages/client/src/shared/ui/ScrollTopButton.tsx
+++ b/packages/client/src/shared/ui/ScrollTopButton.tsx
@@ -12,7 +12,7 @@ function ScrollToTopButton({ right = 'right-2 sm:right-10', bottom = 'bottom-4' 
   return (
     <button
       aria-label="맨 위로 가기"
-      className={`fixed ${bottom} ${right} z-floating w-12 h-12 rounded-full bg-blue-500 text-white shadow-lg
+      className={`fixed ${bottom} ${right} z-floating w-12 h-12 rounded-full bg-primary-500 text-white shadow-lg
                   flex justify-center items-center cursor-pointer transition-opacity duration-200
                   ${isVisible ? 'opacity-100' : 'opacity-0 pointer-events-none'}`}
       onClick={scrollToTop}

--- a/packages/client/src/shared/ui/ScrollTopButton.tsx
+++ b/packages/client/src/shared/ui/ScrollTopButton.tsx
@@ -12,7 +12,7 @@ function ScrollToTopButton({ right = 'right-2 sm:right-10', bottom = 'bottom-4' 
   return (
     <button
       aria-label="맨 위로 가기"
-      className={`fixed ${bottom} ${right} z-50 w-12 h-12 rounded-full bg-blue-500 text-white shadow-lg 
+      className={`fixed ${bottom} ${right} z-floating w-12 h-12 rounded-full bg-blue-500 text-white shadow-lg
                   flex justify-center items-center cursor-pointer transition-opacity duration-200
                   ${isVisible ? 'opacity-100' : 'opacity-0 pointer-events-none'}`}
       onClick={scrollToTop}

--- a/packages/client/src/shared/ui/bottomsheet/BottomSheet.tsx
+++ b/packages/client/src/shared/ui/bottomsheet/BottomSheet.tsx
@@ -22,7 +22,6 @@ function BottomSheet({ children }: IBottomSheet) {
   const { cancelSchedule } = useScheduleModal();
   const [isInitialized, setIsInitialized] = useState(false);
 
-  
   // 초기 렌더링 후 transition 활성화
   useEffect(() => {
     const timer = setTimeout(() => {
@@ -39,7 +38,7 @@ function BottomSheet({ children }: IBottomSheet) {
   useCloseBottomSheetOnBackKey();
 
   return (
-    <div className="fixed inset-0 z-[200]">
+    <div className="fixed inset-0 z-bottomSheet">
       {type && (
         <div
           className="absolute inset-0 bg-black/5 bg-opacity-80"
@@ -50,7 +49,7 @@ function BottomSheet({ children }: IBottomSheet) {
 
       <div
         ref={sheet}
-        className={`fixed rounded-t-xl bottom-0 left-0 w-full bg-white z-200 ${
+        className={`fixed rounded-t-xl bottom-0 left-0 w-full bg-white z-bottomSheet ${
           isInitialized ? 'transition-transform duration-300' : ''
         }`}
         style={{

--- a/packages/client/src/widgets/filtering/search/ui/ScheduleSearchBottomSheet.tsx
+++ b/packages/client/src/widgets/filtering/search/ui/ScheduleSearchBottomSheet.tsx
@@ -42,7 +42,7 @@ function ScheduleSearchBottomSheet({ onCloseSearch, onOpenFiltering }: ISearchBo
             onClick={() => openScheduleModal(initSchedule)}
           />
 
-          <div className="sticky px-2 top-0 bg-white z-10 flex items-center gap-2 py-3">
+          <div className="sticky px-2 top-0 bg-white z-content flex items-center gap-2 py-3">
             <SearchBox
               type="text"
               placeholder="과목명 및 교수명 검색"

--- a/packages/client/src/widgets/home/ui/FeedbacksSection.tsx
+++ b/packages/client/src/widgets/home/ui/FeedbacksSection.tsx
@@ -7,7 +7,7 @@ function FeedbacksSection() {
     <Section className="text-center">
       <Heading level={2}>올클을 써보신 분들의 한마디!</Heading>
       <div className="overflow-hidden mt-6 relative">
-        <div className="absolute top-0 left-0 w-12 h-full bg-gradient-to-r from-gray-50 to-transparent z-10"></div>
+        <div className="absolute top-0 left-0 w-12 h-full bg-gradient-to-r from-gray-50 to-transparent z-content"></div>
         <div className="animate-marquee flex gap-6 flex-nowrap w-fit">
           {UserFeedbacks.map((feedback, index) => (
             <UserFeedbackCard key={'feedback-left-' + index} {...feedback} />
@@ -16,7 +16,7 @@ function FeedbacksSection() {
             <UserFeedbackCard key={'feedback-right-' + index} {...feedback} />
           ))}
         </div>
-        <div className="absolute top-0 right-0 w-12 h-full bg-gradient-to-l from-gray-50 to-transparent z-10"></div>
+        <div className="absolute top-0 right-0 w-12 h-full bg-gradient-to-l from-gray-50 to-transparent z-content"></div>
       </div>
     </Section>
   );

--- a/packages/client/src/widgets/home/ui/LiveSection.tsx
+++ b/packages/client/src/widgets/home/ui/LiveSection.tsx
@@ -44,7 +44,7 @@ function LiveSection() {
           <div className="overflow-x-auto">
             <table className="w-full bg-white rounded-lg text-sm">
               <thead>
-                <tr className="bg-gray-50 z-10 text-nowrap">
+                <tr className="bg-gray-50 z-content text-nowrap">
                   <th className="px-4 py-2">학수번호</th>
                   <th className="px-4 py-2">과목명</th>
                   <th className="px-4 py-2">교수명</th>

--- a/packages/client/src/widgets/home/ui/MainBanner.tsx
+++ b/packages/client/src/widgets/home/ui/MainBanner.tsx
@@ -14,7 +14,7 @@ function MainBanner() {
   return (
     <div className="relative overflow-hidden">
       <Section
-        className="relative z-20 flex flex-col md:flex-row items-center justify-between !py-5"
+        className="relative z-elevated flex flex-col md:flex-row items-center justify-between !py-5"
         bgColor="bg-banner-skysoft"
       >
         <div className="max-w-xl">

--- a/packages/client/src/widgets/live/board/ui/RealtimeTable.tsx
+++ b/packages/client/src/widgets/live/board/ui/RealtimeTable.tsx
@@ -57,7 +57,7 @@ const RealtimeTable = ({ title = '교양과목' }: Readonly<IRealtimeTable>) => 
       <div className="overflow-x-auto">
         <table className="w-full bg-white rounded-lg text-sm">
           <thead>
-            <tr className="bg-gray-50 sticky top-0 z-10 text-nowrap">
+            <tr className="bg-gray-50 sticky top-0 z-content text-nowrap">
               {tableTitles
                 .filter(t => t.visible)
                 .map(({ title }) => (

--- a/packages/client/src/widgets/live/pin/ui/PinSearchBottomSheet.tsx
+++ b/packages/client/src/widgets/live/pin/ui/PinSearchBottomSheet.tsx
@@ -39,7 +39,7 @@ function PinSearchBottomSheet({ onCloseSearch }: ISearchBottomSheet) {
             onClick={expandToMax}
           />
 
-          <div className="sticky py-3 px-2 top-0 bg-white z-10 flex flex-col gap-2 mb-4 flex-auto">
+          <div className="sticky py-3 px-2 top-0 bg-white z-content flex flex-col gap-2 mb-4 flex-auto">
             <SearchBox
               placeholder="과목명 교수명 검색"
               onChange={e => setSearchInput(e.target.value)}

--- a/packages/client/src/widgets/live/pin/ui/PinSearchSideBar.tsx
+++ b/packages/client/src/widgets/live/pin/ui/PinSearchSideBar.tsx
@@ -25,7 +25,7 @@ const transitionClasses = {
 function PinSearchSideBar({ isOpen, onClose }: PinSearchSideBarProps) {
   return (
     <CSSTransition in={isOpen} timeout={100} classNames={transitionClasses} unmountOnExit>
-      <Flex direction="flex-col" className="w-92 flex-auto bg-gray-50 shadow-lg z-10">
+      <Flex direction="flex-col" className="w-92 flex-auto bg-gray-50 shadow-lg z-content">
         <div className="flex justify-between items-center py-2 pl-4 pr-2 bg-white border-b border-gray-200">
           <Heading level={2}>알림 설정</Heading>
           <IconButton aria-label="알림 설정 닫기" icon={<XSvg className="w-4 h-4" />} onClick={onClose} />

--- a/packages/client/src/widgets/simulation/detail/Timeline.tsx
+++ b/packages/client/src/widgets/simulation/detail/Timeline.tsx
@@ -50,7 +50,10 @@ function Timeline({ result }: Readonly<{ result: ExtendedResultResponse }>) {
             style={{ width: `${TICK_WIDTH * timelineTicks.length}px` }}
           >
             {/* subject info */}
-            <div className="py-2 text-sm md:sticky left-0 right-0 z-10 bg-white" style={{ width: `${HEADER_WIDTH}px` }}>
+            <div
+              className="py-2 text-sm md:sticky left-0 right-0 z-content bg-white"
+              style={{ width: `${HEADER_WIDTH}px` }}
+            >
               <div className={`font-semibold ${getTextColor600(subject.color)}`}>{subject.name}</div>
               <span className={`text-xs ${getTextColor500(subject.color)}`}>{subject.code}</span>
             </div>
@@ -116,7 +119,7 @@ function TimelineDot({
 
       {/* Tooltip wrapper */}
       <div
-        className={`absolute z-10 ${tooltipPos} left-1/2 -translate-x-1/2 px-2 py-1 rounded bg-black text-white text-nowrap text-xs text-center opacity-0 peer-hover:opacity-100 transition-opacity duration-200`}
+        className={`absolute z-content ${tooltipPos} left-1/2 -translate-x-1/2 px-2 py-1 rounded bg-black text-white text-nowrap text-xs text-center opacity-0 peer-hover:opacity-100 transition-opacity duration-200`}
       >
         {eventTitle}
         <br />

--- a/packages/client/src/widgets/simulation/modal/Modal.tsx
+++ b/packages/client/src/widgets/simulation/modal/Modal.tsx
@@ -27,7 +27,7 @@ function Modal({ children, onClose, preventAutoFocus }: Readonly<IModalProps>) {
   // Todo: aria-labelledby, aria-describedby 추가
   return (
     <div
-      className="flex items-center justify-center fixed inset-0 w-full h-full z-100"
+      className="flex items-center justify-center fixed inset-0 w-full h-full z-modal"
       role="none"
       ref={containerRef}
       tabIndex={-1}
@@ -36,7 +36,7 @@ function Modal({ children, onClose, preventAutoFocus }: Readonly<IModalProps>) {
       <div className="fixed inset-0 justify-center opacity-30 bg-gray-300 border-b-2 border-gray-400" />
       <div className="fixed inset-x-0 top-16 bottom-0 flex items-center justify-center" tabIndex={-1}>
         <div
-          className="w-[95%] sm:w-fit z-50 bg-white max-h-[90%] border border-gray-200 overflow-y-auto"
+          className="w-[95%] sm:w-fit z-floating bg-white max-h-[90%] border border-gray-200 overflow-y-auto"
           role="dialog"
           tabIndex={-1}
           onClick={e => e.stopPropagation()}

--- a/packages/client/src/widgets/simulation/modal/SimulationResultModal.tsx
+++ b/packages/client/src/widgets/simulation/modal/SimulationResultModal.tsx
@@ -24,6 +24,22 @@ function SimulationResultModal({ simulationId }: Readonly<{ simulationId: number
     }
   });
 
+  useEffect(() => {
+    async function fetchResult() {
+      getSummaryResult({ simulationId }).then(result => {
+        if ('errMsg' in result) {
+          if (result.errMsg === SIMULATION_ERROR.SIMULATION_NOT_FOUND) {
+            closeModal();
+          } else alert(result.errMsg);
+        } else {
+          setResult(result);
+          setLogParam(simulationId);
+        }
+      });
+    }
+    fetchResult().then();
+  }, []);
+
   if (simulationAllResult && 'error' in simulationAllResult) {
     return <div className="flex flex-col w-full items-center justify-center h-120 gap-3"></div>;
   }
@@ -42,22 +58,6 @@ function SimulationResultModal({ simulationId }: Readonly<{ simulationId: number
         },
       }
     : undefined;
-
-  useEffect(() => {
-    async function fetchResult() {
-      getSummaryResult({ simulationId }).then(result => {
-        if ('errMsg' in result) {
-          if (result.errMsg === SIMULATION_ERROR.SIMULATION_NOT_FOUND) {
-            closeModal();
-          } else alert(result.errMsg);
-        } else {
-          setResult(result);
-          setLogParam(simulationId);
-        }
-      });
-    }
-    fetchResult().then();
-  }, []);
 
   if (!result) {
     return <ProcessingModal />;
@@ -82,7 +82,7 @@ function SimulationResultModal({ simulationId }: Readonly<{ simulationId: number
             <div className="animate-float5 absolute top-1/2 left-1/2 w-2 h-2 bg-purple-400 rounded-full" />
           </div>
         )}
-        <div className="relative z-10 text-center">
+        <div className="relative z-content text-center">
           <h2 className="text-xl font-bold text-gray-900">
             수강 신청
             <span className={isSuccessSimulation ? `text-blue-600` : `text-red-500`}>

--- a/packages/client/src/widgets/timetable/Schedule.tsx
+++ b/packages/client/src/widgets/timetable/Schedule.tsx
@@ -78,7 +78,9 @@ function Schedule({
   return (
     <div
       ref={ref}
-      className={`flex absolute ${bgLight} rounded-l-xs cursor-pointer hover:z-20 focus:z-20 ` + attrs.className}
+      className={
+        `flex absolute ${bgLight} rounded-l-xs cursor-pointer hover:z-elevated focus:z-elevated ` + attrs.className
+      }
       onMouseDown={onMouseDown}
       onKeyDown={onKeyDown}
       tabIndex={0}

--- a/packages/client/src/widgets/timetable/TimetableGridComponent.tsx
+++ b/packages/client/src/widgets/timetable/TimetableGridComponent.tsx
@@ -61,7 +61,7 @@ function TimetableGridComponent({ rowHeight = ROW_HEIGHT, colNames, rowNames, ch
       <div
         id="timetable"
         ref={timetableRef}
-        className="absolute inset-0 flex z-10"
+        className="absolute inset-0 flex z-content"
         style={{ top: `${headerHeight}px`, left: `${headerWidth}px` }}
       >
         {children}

--- a/packages/client/src/widgets/timetable/WireSchedules.tsx
+++ b/packages/client/src/widgets/timetable/WireSchedules.tsx
@@ -47,10 +47,12 @@ function WireSchedules({ dayOfWeeks }: Readonly<IWireSchedulesProps>) {
 }
 
 function WireSchedule({ title, professor, location, ...attrs }: Readonly<IScheduleProps>) {
+  // timeslotIndex 는 DOM 으로 전파되지 않도록 의도적으로 분리해 버린다.
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { timeslotIndex: _, ...rest } = attrs;
   return (
     <div
-      className={`flex absolute rounded-md z-20 
+      className={`flex absolute rounded-md z-elevated
       border-violet-500 border-2 md:border-4
       ${attrs.className}`}
       style={{ ...attrs.style }}

--- a/packages/client/src/widgets/wishlist/Table.tsx
+++ b/packages/client/src/widgets/wishlist/Table.tsx
@@ -37,7 +37,7 @@ function Table({ data, isPending = false, placeholder }: Readonly<ITable>) {
   return (
     <table className="w-full bg-white rounded-lg relative text-sm">
       <thead>
-        <tr className="bg-gray-50 sticky top-0 z-10 text-nowrap">
+        <tr className="bg-gray-50 sticky top-0 z-content text-nowrap">
           {headers.map(({ title }) => (
             <th key={'table-header-name-' + title} className="px-4 py-2">
               {title}

--- a/packages/client/tailwind.config.ts
+++ b/packages/client/tailwind.config.ts
@@ -1,5 +1,7 @@
 import { Config } from 'tailwindcss';
+import typography from '@tailwindcss/typography';
 import { colors } from '@allcll/allcll-ui/colors';
+import { Z_INDEX } from '@allcll/allcll-ui/zIndex';
 
 /** @type {import('tailwindcss').Config} */
 const config: Config = {
@@ -14,6 +16,8 @@ const config: Config = {
       fontFamily: {
         sans: ['Pretendard'],
       },
+      // z-index 는 @allcll/allcll-ui/zIndex 에서 단일 관리 (z-content, z-modal 등 생성)
+      zIndex: Object.fromEntries(Object.entries(Z_INDEX).map(([key, value]) => [key, String(value)])),
       colors: {
         primary: colors.primary,
         secondary: colors.secondary,
@@ -42,7 +46,7 @@ const config: Config = {
       },
     },
   },
-  plugins: [require('@tailwindcss/typography')],
+  plugins: [typography],
 };
 
 export default config;

--- a/packages/common/src/components/graduation/EarnedCoursesSection.tsx
+++ b/packages/common/src/components/graduation/EarnedCoursesSection.tsx
@@ -114,7 +114,7 @@ function EarnedCoursesSection({ courses }: Readonly<EarnedCoursesSectionProps>) 
                       onClick={() => setIsSelectOpen(prev => !prev)}
                     />
                     {isSelectOpen && (
-                      <div className="absolute z-10 mt-1 bg-white border border-gray-200 rounded-md shadow-lg max-h-60 overflow-auto min-w-30">
+                      <div className="absolute z-content mt-1 bg-white border border-gray-200 rounded-md shadow-lg max-h-60 overflow-auto min-w-30">
                         {categoryOptions.map(option => (
                           <ListboxOption
                             key={option.value}

--- a/packages/common/src/components/modal/Modal.tsx
+++ b/packages/common/src/components/modal/Modal.tsx
@@ -27,7 +27,7 @@ function Modal({ children, onClose, preventAutoFocus }: Readonly<IModalProps>) {
   // Todo: aria-labelledby, aria-describedby 추가
   return (
     <div
-      className="flex items-center justify-center fixed inset-0 w-full h-full z-100"
+      className="flex items-center justify-center fixed inset-0 w-full h-full z-modal"
       role="none"
       ref={containerRef}
       tabIndex={-1}
@@ -36,7 +36,7 @@ function Modal({ children, onClose, preventAutoFocus }: Readonly<IModalProps>) {
       <div className="fixed inset-0 justify-center opacity-30 bg-gray-300 border-b-2 border-gray-400" />
       <div className="flex items-center justify-center" tabIndex={-1}>
         <div
-          className="rounded-lg z-50 bg-white max-h-[90vh] border border-gray-200 overflow-y-auto"
+          className="rounded-lg z-floating bg-white max-h-[90vh] border border-gray-200 overflow-y-auto"
           role="dialog"
           tabIndex={-1}
           onClick={e => e.stopPropagation()}

--- a/packages/common/src/components/toast/ToastNotification.tsx
+++ b/packages/common/src/components/toast/ToastNotification.tsx
@@ -9,7 +9,7 @@ function ToastNotification() {
   const closeToast = useToastNotification(state => state.clearToast);
 
   return (
-    <div className="fixed top-2 right-2 z-100 max-w-screen">
+    <div className="fixed top-2 right-2 z-toast max-w-screen">
       <TransitionGroup className="flex gap-2 flex-col-reverse">
         {messages.slice(-3).map((message, index) => (
           <CSSTransition key={`${index} : ${message}`} timeout={300} classNames="toast">

--- a/packages/common/tailwind.config.ts
+++ b/packages/common/tailwind.config.ts
@@ -1,10 +1,13 @@
 import { Config } from 'tailwindcss';
+import { Z_INDEX } from '@allcll/allcll-ui/zIndex';
 
 /** @type {import('tailwindcss').Config} */
 const config: Config = {
   content: ['./src/**/*.{html,js,jsx,ts,tsx}'],
   theme: {
     extend: {
+      // z-index 단일 관리: @allcll/allcll-ui/zIndex (z-content, z-modal 등 생성)
+      zIndex: Object.fromEntries(Object.entries(Z_INDEX).map(([key, value]) => [key, String(value)])),
       colors: {
         primary: '#007aff',
         blue: {

--- a/packages/common/tailwind.config.ts
+++ b/packages/common/tailwind.config.ts
@@ -1,4 +1,5 @@
 import { Config } from 'tailwindcss';
+import { colors } from '@allcll/allcll-ui/colors';
 import { Z_INDEX } from '@allcll/allcll-ui/zIndex';
 
 /** @type {import('tailwindcss').Config} */
@@ -8,8 +9,9 @@ const config: Config = {
     extend: {
       // z-index 단일 관리: @allcll/allcll-ui/zIndex (z-content, z-modal 등 생성)
       zIndex: Object.fromEntries(Object.entries(Z_INDEX).map(([key, value]) => [key, String(value)])),
+      // colors 단일 관리: @allcll/allcll-ui/colors (client 기준으로 통일)
       colors: {
-        primary: '#007aff',
+        primary: colors.primary,
         blue: {
           500: '#007aff',
         },

--- a/packages/sejong-ui/src/asideMenu/AsideMenu.tsx
+++ b/packages/sejong-ui/src/asideMenu/AsideMenu.tsx
@@ -17,7 +17,7 @@ function AsideMenu({ menus }: AsideMenuProps) {
   return (
     <aside
       className={
-        (isOpen ? 'relative z-10' : 'relative bg-blue-50 z-10') +
+        (isOpen ? 'relative z-content' : 'relative bg-blue-50 z-content') +
         (!isOpen || isMobile ? ' w-[20px] min-w-[20px] h-[calc(100vh-60px)]' : ' w-[230px] min-w-[230px]')
       }
     >

--- a/packages/sejong-ui/src/modal/Modal.tsx
+++ b/packages/sejong-ui/src/modal/Modal.tsx
@@ -30,7 +30,7 @@ function Modal({ children, onBackdropClick, preventAutoFocus, noBorder }: Readon
   };
 
   return (
-    <div className="fixed inset-0 z-100 flex items-center justify-center">
+    <div className="fixed inset-0 z-modal flex items-center justify-center">
       <button
         type="button"
         aria-label="Close dialog"

--- a/packages/sejong-ui/tailwind.config.ts
+++ b/packages/sejong-ui/tailwind.config.ts
@@ -1,10 +1,15 @@
 import type { Config } from 'tailwindcss';
+// z-index 는 디자인 시스템(allcll-ui)에서 단일 관리. sejong-ui 는 allcll-ui 를 런타임 의존하지
+// 않으므로, 빌드타임 config 로드용으로만 형제 패키지를 상대경로로 참조한다.
+import { Z_INDEX } from '../allcll-ui/zIndex';
 
 /** @type {import('tailwindcss').Config} */
 const config: Config = {
   content: ['./src/**/*.{html,js,jsx,ts,tsx}'],
   theme: {
     extend: {
+      // z-index 단일 관리 (z-content, z-modal 등 생성)
+      zIndex: Object.fromEntries(Object.entries(Z_INDEX).map(([key, value]) => [key, String(value)])),
       colors: {
         primary: '#007aff',
         blue: {

--- a/packages/sejong-ui/tailwind.config.ts
+++ b/packages/sejong-ui/tailwind.config.ts
@@ -2,6 +2,7 @@ import type { Config } from 'tailwindcss';
 // z-index 는 디자인 시스템(allcll-ui)에서 단일 관리. sejong-ui 는 allcll-ui 를 런타임 의존하지
 // 않으므로, 빌드타임 config 로드용으로만 형제 패키지를 상대경로로 참조한다.
 import { Z_INDEX } from '../allcll-ui/zIndex';
+import { colors } from '../allcll-ui/colors';
 
 /** @type {import('tailwindcss').Config} */
 const config: Config = {
@@ -10,8 +11,9 @@ const config: Config = {
     extend: {
       // z-index 단일 관리 (z-content, z-modal 등 생성)
       zIndex: Object.fromEntries(Object.entries(Z_INDEX).map(([key, value]) => [key, String(value)])),
+      // colors 단일 관리: allcll-ui/colors (client 기준으로 통일)
       colors: {
-        primary: '#007aff',
+        primary: colors.primary,
         blue: {
           500: '#007aff',
         },


### PR DESCRIPTION
## 관련 이슈
- Closes https://github.com/allcll/allcll-frontend/issues/356
## 작업 내용
- 여러 컴포넌트에 매직 넘버로 흩어져 있던 z-index 상수들을 단일 소스로 중앙화했습니다.
- 디자인 시스템(allcll-ui)에 zIndex.ts 토큰 파일을 신설하고, 각 패키지 tailwind config가 이를 공유하도록 구성했습니다.
- client / common / admin / sejong-ui / allcll-ui 전 패키지의 z-index 매직 넘버를 시맨틱 토큰(z-content, z-modal, z-toast 등)으로 교체했습니다.
- 인라인 style로 z-index를 지정하던 곳(PopoverContent, DraggableList)도 동일한 토큰 값을 참조하도록 통일했습니다.
- common 토스트가 모달과 같은 레이어(z-100)에 있던 것을 최상단(z-toast, 400)으로 정규화했습니다.

## 변경 사항 및 리뷰 포인트
- 컬러 토큰의 경우, common / sejong-ui는 primary가 #007aff 단일값이고 allcll-ui는 스케일(#3B82F6…)이라 값 자체가 서로 달라, 이번에는 순수 중복이던 allcll-ui config의 인라인 정의만 제거하고 값 통합은 하지 않았습니다. 통합이 필요한지 판단 부탁드립니다.
- common 토스트의 z-index를 100 → 400으로 올린 것이 이번 PR의 유일한 동작 변경입니다. 기존에는 토스트와 모달이 같은 레이어라 겹칠 때 순서가 불안정했는데, 토스트가 항상 모달 위로 표시되도록 정규화했습니다.
- 커밋 시 lint-staged가 변경 라인이 아닌 파일 전체를 검사하면서, z-index 때문에 건드린 파일들에 원래부터 있던 lint 에러 3개가 함께 걸려 부득이하게 수정했습니다.
 
 
이번 PR은 기능 변경 없이 z-index 관리 방식만 정리하는 리팩터링이긴 하지만 혹시 놓친 부분이 있다면 말씀해주세요!