### PR TITLE
feat: 어드민 사용자 후기 등록일 표시 및 정렬 기능

### DIFF
--- a/packages/admin/src/components/reviews/ReviewItem.tsx
+++ b/packages/admin/src/components/reviews/ReviewItem.tsx
@@ -1,16 +1,17 @@
 import { useState, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Badge, Flex, IconButton, SupportingText } from '@allcll/allcll-ui';
-import { Review, OPERATION_TYPE_LABEL, MAX_RATE } from '@/hooks/server/useAdminReviews';
+import { OPERATION_TYPE_LABEL, MAX_RATE } from '@/hooks/server/useAdminReviews';
+import type { Review } from '@/hooks/server/useAdminReviews';
 import { formatDateTime } from '@/utils/formatTime';
 import CiIcon from '@/assets/ci-icon.svg?react';
 import ArrowDownSvg from '@/assets/arrow-down.svg?react';
 
-interface ReviewItemProps {
+interface IReviewItemProps {
   review: Review;
 }
 
-function ReviewItem({ review }: Readonly<ReviewItemProps>) {
+function ReviewItem({ review }: Readonly<IReviewItemProps>) {
   const navigate = useNavigate();
   const [isExpanded, setIsExpanded] = useState(false);
   const [isClamped, setIsClamped] = useState(false);

--- a/packages/admin/src/components/reviews/ReviewItem.tsx
+++ b/packages/admin/src/components/reviews/ReviewItem.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Badge, Flex, IconButton, SupportingText } from '@allcll/allcll-ui';
 import { Review, OPERATION_TYPE_LABEL, MAX_RATE } from '@/hooks/server/useAdminReviews';
+import { formatDateTime } from '@/utils/formatTime';
 import CiIcon from '@/assets/ci-icon.svg?react';
 import ArrowDownSvg from '@/assets/arrow-down.svg?react';
 
@@ -25,6 +26,9 @@ function ReviewItem({ review }: Readonly<ReviewItemProps>) {
 
   return (
     <tr className="bg-white hover:bg-gray-50 transition-colors border-b border-gray-100 last:border-0">
+      <td className="px-4 py-3 align-top w-36">
+        <SupportingText className="whitespace-nowrap">{formatDateTime(review.createdAt)}</SupportingText>
+      </td>
       <td className="px-4 py-3 align-top w-28">
         {isGraduation ? (
           <button

--- a/packages/admin/src/components/reviews/ReviewItem.tsx
+++ b/packages/admin/src/components/reviews/ReviewItem.tsx
@@ -26,9 +26,6 @@ function ReviewItem({ review }: Readonly<ReviewItemProps>) {
 
   return (
     <tr className="bg-white hover:bg-gray-50 transition-colors border-b border-gray-100 last:border-0">
-      <td className="px-4 py-3 align-top w-36">
-        <SupportingText className="whitespace-nowrap">{formatDateTime(review.createdAt)}</SupportingText>
-      </td>
       <td className="px-4 py-3 align-top w-28">
         {isGraduation ? (
           <button
@@ -79,6 +76,9 @@ function ReviewItem({ review }: Readonly<ReviewItemProps>) {
             />
           )}
         </Flex>
+      </td>
+      <td className="px-4 py-3 align-top w-36">
+        <SupportingText className="whitespace-nowrap">{formatDateTime(review.createdAt)}</SupportingText>
       </td>
     </tr>
   );

--- a/packages/admin/src/components/reviews/ReviewList.tsx
+++ b/packages/admin/src/components/reviews/ReviewList.tsx
@@ -22,11 +22,11 @@ function ReviewList({ reviews, isLoading, isError, filterBar }: Readonly<ReviewL
           <table className="w-full border-collapse table-fixed">
             <thead className="sticky top-0 z-10">
               <tr className="bg-gray-50 text-sm text-gray-500">
-                <th className="text-left px-4 py-2 font-medium w-36">등록일</th>
                 <th className="text-left px-4 py-2 font-medium w-28">학번</th>
                 <th className="text-left px-4 py-2 font-medium w-32">도메인</th>
                 <th className="text-left px-4 py-2 font-medium w-24">평점</th>
                 <th className="text-left px-4 py-2 font-medium">후기 내용</th>
+                <th className="text-left px-4 py-2 font-medium w-36">등록일</th>
               </tr>
             </thead>
             <tbody>

--- a/packages/admin/src/components/reviews/ReviewList.tsx
+++ b/packages/admin/src/components/reviews/ReviewList.tsx
@@ -1,5 +1,5 @@
 import { Card, Flex, SupportingText } from '@allcll/allcll-ui';
-import { Review } from '@/hooks/server/useAdminReviews';
+import type { Review } from '@/hooks/server/useAdminReviews';
 import ReviewItem from './ReviewItem';
 import SectionHeader from '@/components/common/SectionHeader';
 
@@ -12,14 +12,14 @@ const COLUMNS: { label: string; width: string }[] = [
   { label: '등록일', width: 'w-36' },
 ];
 
-interface ReviewListProps {
+interface IReviewListProps {
   reviews: Review[];
   isLoading: boolean;
   isError: boolean;
   filterBar?: React.ReactNode;
 }
 
-function ReviewList({ reviews, isLoading, isError, filterBar }: Readonly<ReviewListProps>) {
+function ReviewList({ reviews, isLoading, isError, filterBar }: Readonly<IReviewListProps>) {
   return (
     <Flex direction="flex-col" gap="gap-2" className="h-full">
       <SectionHeader title="후기 목록" description="서비스별 사용자 후기를 확인합니다." />

--- a/packages/admin/src/components/reviews/ReviewList.tsx
+++ b/packages/admin/src/components/reviews/ReviewList.tsx
@@ -3,6 +3,15 @@ import { Review } from '@/hooks/server/useAdminReviews';
 import ReviewItem from './ReviewItem';
 import SectionHeader from '@/components/common/SectionHeader';
 
+// 순서는 ReviewItem의 셀 순서와 일치해야 함
+const COLUMNS: { label: string; width: string }[] = [
+  { label: '학번', width: 'w-28' },
+  { label: '도메인', width: 'w-32' },
+  { label: '평점', width: 'w-24' },
+  { label: '후기 내용', width: '' },
+  { label: '등록일', width: 'w-36' },
+];
+
 interface ReviewListProps {
   reviews: Review[];
   isLoading: boolean;
@@ -22,31 +31,31 @@ function ReviewList({ reviews, isLoading, isError, filterBar }: Readonly<ReviewL
           <table className="w-full border-collapse table-fixed">
             <thead className="sticky top-0 z-10">
               <tr className="bg-gray-50 text-sm text-gray-500">
-                <th className="text-left px-4 py-2 font-medium w-28">학번</th>
-                <th className="text-left px-4 py-2 font-medium w-32">도메인</th>
-                <th className="text-left px-4 py-2 font-medium w-24">평점</th>
-                <th className="text-left px-4 py-2 font-medium">후기 내용</th>
-                <th className="text-left px-4 py-2 font-medium w-36">등록일</th>
+                {COLUMNS.map(column => (
+                  <th key={column.label} className={`text-left px-4 py-2 font-medium ${column.width}`}>
+                    {column.label}
+                  </th>
+                ))}
               </tr>
             </thead>
             <tbody>
               {isLoading && (
                 <tr>
-                  <td colSpan={5} className="py-8 text-center">
+                  <td colSpan={COLUMNS.length} className="py-8 text-center">
                     <SupportingText>불러오는 중...</SupportingText>
                   </td>
                 </tr>
               )}
               {!isLoading && isError && (
                 <tr>
-                  <td colSpan={5} className="py-8 text-center text-sm text-red-500">
+                  <td colSpan={COLUMNS.length} className="py-8 text-center text-sm text-red-500">
                     후기 데이터를 불러오는데 실패했습니다.
                   </td>
                 </tr>
               )}
               {!isLoading && !isError && reviews.length === 0 && (
                 <tr>
-                  <td colSpan={5} className="py-8 text-center">
+                  <td colSpan={COLUMNS.length} className="py-8 text-center">
                     <SupportingText>등록된 후기가 없습니다.</SupportingText>
                   </td>
                 </tr>

--- a/packages/admin/src/components/reviews/ReviewList.tsx
+++ b/packages/admin/src/components/reviews/ReviewList.tsx
@@ -22,6 +22,7 @@ function ReviewList({ reviews, isLoading, isError, filterBar }: Readonly<ReviewL
           <table className="w-full border-collapse table-fixed">
             <thead className="sticky top-0 z-10">
               <tr className="bg-gray-50 text-sm text-gray-500">
+                <th className="text-left px-4 py-2 font-medium w-36">등록일</th>
                 <th className="text-left px-4 py-2 font-medium w-28">학번</th>
                 <th className="text-left px-4 py-2 font-medium w-32">도메인</th>
                 <th className="text-left px-4 py-2 font-medium w-24">평점</th>
@@ -31,21 +32,21 @@ function ReviewList({ reviews, isLoading, isError, filterBar }: Readonly<ReviewL
             <tbody>
               {isLoading && (
                 <tr>
-                  <td colSpan={4} className="py-8 text-center">
+                  <td colSpan={5} className="py-8 text-center">
                     <SupportingText>불러오는 중...</SupportingText>
                   </td>
                 </tr>
               )}
               {!isLoading && isError && (
                 <tr>
-                  <td colSpan={4} className="py-8 text-center text-sm text-red-500">
+                  <td colSpan={5} className="py-8 text-center text-sm text-red-500">
                     후기 데이터를 불러오는데 실패했습니다.
                   </td>
                 </tr>
               )}
               {!isLoading && !isError && reviews.length === 0 && (
                 <tr>
-                  <td colSpan={4} className="py-8 text-center">
+                  <td colSpan={5} className="py-8 text-center">
                     <SupportingText>등록된 후기가 없습니다.</SupportingText>
                   </td>
                 </tr>

--- a/packages/admin/src/hooks/server/useAdminReviews.ts
+++ b/packages/admin/src/hooks/server/useAdminReviews.ts
@@ -23,6 +23,7 @@ export interface Review {
   rate: 1 | 2 | 3;
   detail: string;
   operationType: OperationType;
+  createdAt: string;
 }
 
 interface ReviewsResponse {

--- a/packages/admin/src/pages/Reviews.tsx
+++ b/packages/admin/src/pages/Reviews.tsx
@@ -2,7 +2,8 @@ import { useMemo, useState } from 'react';
 import PageHeader from '@/components/common/PageHeader';
 import ReviewList from '@/components/reviews/ReviewList';
 import ReviewStats from '@/components/reviews/ReviewStats';
-import { useAdminReviews, OPERATION_TYPE_LABEL, Review } from '@/hooks/server/useAdminReviews';
+import { useAdminReviews, OPERATION_TYPE_LABEL } from '@/hooks/server/useAdminReviews';
+import type { Review } from '@/hooks/server/useAdminReviews';
 import { Filtering, CheckboxAdapter } from '@allcll/common';
 import MultiSelectFilterOption from '@/components/common/MultiSelectFilterOption';
 import { Button, Flex, ListboxOption } from '@allcll/allcll-ui';
@@ -14,7 +15,7 @@ type ReviewSortKey = 'latest' | 'oldest' | 'studentId' | 'rateDesc' | 'rateAsc';
 
 type ReviewComparator = (a: Review, b: Review) => number;
 
-interface ReviewSortOption {
+interface IReviewSortOption {
   value: ReviewSortKey;
   label: string;
   compare: ReviewComparator;
@@ -30,7 +31,7 @@ const compareByCreatedAt =
     return direction === 'asc' ? compared : -compared;
   };
 
-const SORT_OPTIONS: ReviewSortOption[] = [
+const SORT_OPTIONS: IReviewSortOption[] = [
   { value: 'latest', label: '최신순', compare: compareByCreatedAt('desc') },
   { value: 'oldest', label: '오래된순', compare: compareByCreatedAt('asc') },
   { value: 'studentId', label: '학번순', compare: (a, b) => a.studentId.localeCompare(b.studentId) },

--- a/packages/admin/src/pages/Reviews.tsx
+++ b/packages/admin/src/pages/Reviews.tsx
@@ -2,29 +2,61 @@ import { useMemo, useState } from 'react';
 import PageHeader from '@/components/common/PageHeader';
 import ReviewList from '@/components/reviews/ReviewList';
 import ReviewStats from '@/components/reviews/ReviewStats';
-import { useAdminReviews, OPERATION_TYPE_LABEL } from '@/hooks/server/useAdminReviews';
+import { useAdminReviews, OPERATION_TYPE_LABEL, Review } from '@/hooks/server/useAdminReviews';
 import { Filtering, CheckboxAdapter } from '@allcll/common';
 import MultiSelectFilterOption from '@/components/common/MultiSelectFilterOption';
-import { Button, Flex } from '@allcll/allcll-ui';
+import { Button, Flex, ListboxOption } from '@allcll/allcll-ui';
 
 const DOMAIN_OPTIONS = Object.entries(OPERATION_TYPE_LABEL).map(([value, label]) => ({ label, value }));
 const RATING_OPTIONS = [1, 2, 3].map(r => ({ label: `${r}점`, value: String(r) }));
+
+type ReviewSortKey = 'latest' | 'oldest' | 'studentId' | 'rateDesc' | 'rateAsc';
+
+type ReviewComparator = (a: Review, b: Review) => number;
+
+interface ReviewSortOption {
+  value: ReviewSortKey;
+  label: string;
+  compare: ReviewComparator;
+}
+
+// createdAt 누락 데이터는 정렬 방향과 무관하게 항상 맨 뒤로. ISO 문자열은 사전순 = 시간순.
+const compareByCreatedAt =
+  (direction: 'asc' | 'desc'): ReviewComparator =>
+  (a, b) => {
+    if (!a.createdAt) return 1;
+    if (!b.createdAt) return -1;
+    const compared = a.createdAt.localeCompare(b.createdAt);
+    return direction === 'asc' ? compared : -compared;
+  };
+
+const SORT_OPTIONS: ReviewSortOption[] = [
+  { value: 'latest', label: '최신순', compare: compareByCreatedAt('desc') },
+  { value: 'oldest', label: '오래된순', compare: compareByCreatedAt('asc') },
+  { value: 'studentId', label: '학번순', compare: (a, b) => a.studentId.localeCompare(b.studentId) },
+  { value: 'rateDesc', label: '평점 높은순', compare: (a, b) => b.rate - a.rate },
+  { value: 'rateAsc', label: '평점 낮은순', compare: (a, b) => a.rate - b.rate },
+];
 
 function Reviews() {
   const { data: reviews = [], isLoading, isFetching, isError, refetch } = useAdminReviews();
   const [selectedOperationTypes, setSelectedOperationTypes] = useState<string[]>([]);
   const [selectedYears, setSelectedYears] = useState<string[]>([]);
   const [selectedRatings, setSelectedRatings] = useState<string[]>([]);
+  const [sortKey, setSortKey] = useState<ReviewSortKey>('latest');
 
   const yearOptions = useMemo(() => {
     const years = [...new Set(reviews.map(r => r.studentId.substring(0, 2)))].sort((a, b) => a.localeCompare(b));
     return years.map(y => ({ label: `${y}학번`, value: y }));
   }, [reviews]);
 
+  const activeSortOption = SORT_OPTIONS.find(option => option.value === sortKey) ?? SORT_OPTIONS[0];
+
   const filteredReviews = reviews
     .filter(r => !selectedOperationTypes.length || selectedOperationTypes.includes(r.operationType))
     .filter(r => !selectedYears.length || selectedYears.includes(r.studentId.substring(0, 2)))
-    .filter(r => !selectedRatings.length || selectedRatings.includes(String(r.rate)));
+    .filter(r => !selectedRatings.length || selectedRatings.includes(String(r.rate)))
+    .sort(activeSortOption.compare);
 
   const filterBar = (
     <Flex align="items-center" gap="gap-2">
@@ -54,6 +86,18 @@ function Reviews() {
           options={RATING_OPTIONS}
           ItemComponent={CheckboxAdapter}
         />
+      </Filtering>
+      <Filtering label={`정렬: ${activeSortOption.label}`} selected={sortKey !== 'latest'}>
+        <div className="flex flex-col gap-1 min-w-32">
+          {SORT_OPTIONS.map(option => (
+            <ListboxOption
+              key={option.value}
+              selected={sortKey === option.value}
+              onSelect={() => setSortKey(option.value)}
+              left={option.label}
+            />
+          ))}
+        </div>
       </Filtering>
       <div className="ml-auto">
         <Button variant="outlined" size="small" disabled={isFetching} onClick={() => refetch()}>

--- a/packages/admin/src/utils/formatTime.ts
+++ b/packages/admin/src/utils/formatTime.ts
@@ -15,3 +15,15 @@ export const formatTime = (dateString: string) => {
 
   return `${year}-${month}-${day}  ${String(hour).padStart(2, '0')}:${minute}`;
 };
+
+const pad = (value: number) => String(value).padStart(2, '0');
+
+// UTC(Z)로 내려오는 값을 로컬(KST) 24시간제로 표시 (Date getter가 로컬 타임존 변환).
+export const formatDateTime = (dateString: string) => {
+  if (!dateString) return '';
+
+  const date = new Date(dateString);
+  if (Number.isNaN(date.getTime())) return '';
+
+  return `${date.getFullYear()}.${pad(date.getMonth() + 1)}.${pad(date.getDate())} ${pad(date.getHours())}:${pad(date.getMinutes())}`;
+};


### PR DESCRIPTION
## 작업 내용

QA 할 때 어떤 후기가 새로 들어온 건지 기존 건지 구분이 안 된다는 피드백이 있어서 목록에 등록일 추가하고 정렬 기능 넣었습니다.([관련 논의](https://discord.com/channels/1336227271106625609/1357970968122757120/1526460505860866188))

- 등록일 컬럼 추가
- 정렬 추가 (최신순(기본) / 오래된순 / 학번순 / 평점 높은순 / 평점 낮은순)

## 변경 사항 및 리뷰 포인트

### 등록일
백엔드가 이미 내려주고 있던 값인 `createdAt`을 목록에 노출하고 기본 정렬을 날짜순으로 하고 맨 앞 컬럼에 날짜를 두는 방식으로 수정했습니다. 

### 정렬
옆 필터들과 같은 `Filtering` + `ListboxOption` 드롭다운으로 붙임. `SORT_OPTIONS` 배열에 한 줄 추가하면 정렬 기준이 늘어나는 구조입니다.

`createdAt` 없는 데이터는 정렬 방향과 상관없이 항상 맨 뒤로 보내는 방식으로 구현했습니다. 