### PR TITLE
feat: 메인 배너를 2026-2학기 수강신청 기간으로 변경

### DIFF
--- a/packages/client/src/widgets/home/ui/MainBanner.tsx
+++ b/packages/client/src/widgets/home/ui/MainBanner.tsx
@@ -1,16 +1,16 @@
 import { Link } from 'react-router-dom';
 import { Button, SupportingText } from '@allcll/allcll-ui';
-import useServiceSemester from '@/entities/semester/model/useServiceSemester';
 import Section from '@/widgets/home/ui/Section.tsx';
 import Image from '@/shared/ui/Image.tsx';
 import LogoName from '@/assets/logo/logo-name-summer.svg?react';
 
-const START_DATE = '06/01(월)';
-const END_DATE = '06/04(목)';
+// TODO: 학기 롤오버 시 SEMESTER_LABEL을 useServiceSemester의 semesterValue 참조로 되돌리기.
+//       학기/기간 설정 단일화 PR(375번)이 머지되면 이 상수들이 @allcll/common config.ts로 이동하므로 거기서 함께 정리.
+const SEMESTER_LABEL = '2026-2학기';
+const START_DATE = '08/14(금)';
+const END_DATE = '08/21(금)';
 
 function MainBanner() {
-  const { data } = useServiceSemester();
-
   return (
     <div className="relative overflow-hidden">
       <Section
@@ -19,9 +19,9 @@ function MainBanner() {
       >
         <div className="max-w-xl">
           <div className="flex flex-row gap-2 items-center">
-            <Image src="/calendar.png" alt="2026-여름학기 세종대 수강신청 일정 아이콘" className="w-10 h-10" />
+            <Image src="/calendar.png" alt={`${SEMESTER_LABEL} 세종대 수강신청 일정 아이콘`} className="w-10 h-10" />
             <span className="italic text-xs text-stone-500 ">
-              {data?.semesterValue}학기 수강신청 기간 <br />
+              {SEMESTER_LABEL} 수강신청 기간 <br />
               {START_DATE} ~ {END_DATE}
             </span>
           </div>

--- a/packages/client/src/widgets/home/ui/MainBanner.tsx
+++ b/packages/client/src/widgets/home/ui/MainBanner.tsx
@@ -19,7 +19,7 @@ function MainBanner() {
       >
         <div className="max-w-xl">
           <div className="flex flex-row gap-2 items-center">
-            <Image src="/calendar.png" alt={`${SEMESTER_LABEL} 세종대 수강신청 일정 아이콘`} className="w-10 h-10" />
+            <Image src="/calendar.png" alt="" className="w-10 h-10" />
             <span className="italic text-xs text-stone-500 ">
               {SEMESTER_LABEL} 수강신청 기간 <br />
               {START_DATE} ~ {END_DATE}


### PR DESCRIPTION
## 작업 내용

- 메인 배너를 **2026-2학기 수강신청 기간 (08/14 ~ 08/21)** 으로 변경

## 변경 사항 및 리뷰 포인트

**왜 지금 바꾸나 (학기 데이터 공개 전에)**

현재 배너는 이미 지난 여름학기 일정(06/01 ~ 06/04)을 그대로 보여주고 있어, 지금 접속하면 지난 날짜가 안내됩니다. 배너는 단순 안내 문구라 2학기 학기 데이터 공개(7/30)와 무관하게 먼저 바꿀 수 있어서, 지나간 일정 대신 다가오는 2학기 수강신청 일정을 미리 안내하려고 지금 변경합니다.

**학기 이름 표시**

기존엔 `useServiceSemester()`가 주는 현재 학기값으로 학기 이름을 표시했는데, 지금은 서비스가 아직 여름학기라 그대로 쓰면 "2026-여름학기"로 나옵니다. 이번 안내는 가을(2026-2학기) 수강신청이라, 학기 이름을 `2026-2학기`로 직접 지정했고 더는 쓰이지 않는 `useServiceSemester`는 제거했습니다.

2학기로 전환될 때 학기 이름을 다시 자동값으로 되돌리면 됩니다. (코드에 TODO 주석으로 남겨둠) 학기/기간 설정 단일화 PR(375번)이 머지되면 이 상수들이 `@allcll/common` config로 옮겨가니, 그때 함께 정리하면 됩니다.

**범위**

- 이 PR은 배너 문구만 변경합니다.
- 여름학기 과목 데이터 파일(`SUMMER_26/subjects.json`)은 이미 공유한 파일을 사용하면 됩니다.
