### PR TITLE
fix: 바스켓 API 엔드포인트 백엔드 동기화

### DIFF
--- a/packages/admin/src/hooks/server/clawlers/useBasketCrawlers.ts
+++ b/packages/admin/src/hooks/server/clawlers/useBasketCrawlers.ts
@@ -8,7 +8,7 @@ export interface CralwersParams {
 }
 
 const crawlingBasket = async ({ userId }: CralwersParams) => {
-  const response = await fetchOnAPI(`/api/admin/basket?userId=${userId}`, {
+  const response = await fetchOnAPI(`/api/admin/basket/fetch?userId=${userId}`, {
     method: 'POST',
   });
 
@@ -28,8 +28,8 @@ const crawlingBasket = async ({ userId }: CralwersParams) => {
   return response;
 };
 
-const getCrawleredBasket = async ({ userId }: CralwersParams) => {
-  return await fetchJsonOnAPI(`/api/admin/basket?userId=${userId}`);
+const getCrawleredBasket = async () => {
+  return await fetchJsonOnAPI(`/api/baskets`);
 };
 
 /**
@@ -61,9 +61,9 @@ export function useCrawlersBasket() {
  * @param params
  * @returns
  */
-export function useGetBasket(params: CralwersParams) {
+export function useGetBasket() {
   return useQuery({
     queryKey: ['crawlers-basket'],
-    queryFn: () => getCrawleredBasket(params),
+    queryFn: () => getCrawleredBasket(),
   });
 }


### PR DESCRIPTION
## 작업 내용

바스켓 크롤링 API 엔드포인트를 백엔드와 동기화합니다.

## 변경 사항 및 리뷰 포인트

### 변경된 엔드포인트

- **크롤링 시작**: `POST /api/admin/basket?userId=...` → `POST /api/admin/basket/fetch?userId=...`
- **데이터 조회**: `GET /api/admin/basket/fetch?userId=...` → `GET /api/baskets`

### 변경 사유

백엔드 `AdminBasketApi` 확인 결과:
- POST `/api/admin/basket/fetch` 만 구현됨
- GET 메서드 없음
- 다른 크롤러(`AdminPreSeatApi`)와 동일한 구조

데이터 조회는 공개 API인 `GET /api/baskets` 로 변경하여 백엔드와 일치시켰습니다.

### 파일 변경

- `packages/admin/src/hooks/server/clawlers/useBasketCrawlers.ts`
  - `crawlingBasket()`: 엔드포인트 경로 수정
  - `getCrawleredBasket()`: 엔드포인트 및 파라미터 제거