### PR TITLE
fix: primary 색상 토큰 기본값 추가 및 사용처 셰이드 명시

### DIFF
--- a/packages/allcll-ui/colors.ts
+++ b/packages/allcll-ui/colors.ts
@@ -1,5 +1,6 @@
 export const colors = {
   primary: {
+    DEFAULT: '#3B82F6', // primary-500과 동일. text-primary 처럼 셰이드 없이 쓰는 경우를 위한 기본값
     50: '#EFF6FF',
     100: '#DBEAFE',
     200: '#BFDBFE',

--- a/packages/client/src/features/feedback/ui/FeedbackSharedContent.tsx
+++ b/packages/client/src/features/feedback/ui/FeedbackSharedContent.tsx
@@ -39,7 +39,11 @@ export function FeedbackFields({ titles, rate, setRate, detail, setDetail, error
         onChange={e => setDetail(e.target.value)}
       />
 
-      {error && <p className="text-red-600 text-sm mb-3" aria-live='assertive'>{error}</p>}
+      {error && (
+        <p className="text-red-600 text-sm mb-3" aria-live="assertive">
+          {error}
+        </p>
+      )}
     </>
   );
 }
@@ -60,10 +64,14 @@ export function FeedbackActions({ isPending, onDontShowAgain, onSubmit }: Action
 export function FeedbackSuccess() {
   return (
     <Flex direction="flex-col" justify="justify-center" align="items-center" className="py-4">
-      <Flex justify="justify-center" align="items-center" className="w-14 h-14 rounded-full bg-emerald-100 mb-3 animate-pulse">
+      <Flex
+        justify="justify-center"
+        align="items-center"
+        className="w-14 h-14 rounded-full bg-emerald-100 mb-3 animate-pulse"
+      >
         <CheckIcon className="text-emerald-600" />
       </Flex>
-      <SupportingText className="text-primary">좋은 의견 주셔서 감사합니다</SupportingText>
+      <SupportingText className="text-primary-500">좋은 의견 주셔서 감사합니다</SupportingText>
     </Flex>
   );
 }
@@ -89,7 +97,7 @@ function RateInputs({ rate, currentRate, onClick }: RateButtonProps) {
       aria-checked={currentRate === rate}
       aria-label={LabelText}
       className={`flex flex-col items-center gap-2 p-2 rounded-xl transition-colors duration-200 font-bold
-        ${currentRate === rate ? 'text-primary' : 'text-gray-300 hover:text-blue-300'}`}
+        ${currentRate === rate ? 'text-primary-500' : 'text-gray-300 hover:text-blue-300'}`}
       onClick={onClick}
     >
       {faces[rate]}

--- a/packages/client/src/features/graduation/ui/setup/BasicInfoForm.tsx
+++ b/packages/client/src/features/graduation/ui/setup/BasicInfoForm.tsx
@@ -127,7 +127,7 @@ const BasicInfoForm = ({ nextStep, prevStep, isDepartmentNotFound }: BasicInfoFo
           {isDepartmentNotFound && (
             <Flex direction="flex-col" gap="gap-2">
               <SupportingText>
-                <span className="text-primary">26학번의 계열 단위</span>는 특정한 졸업요건이 존재하지 않아, 학과를
+                <span className="text-primary-500">26학번의 계열 단위</span>는 특정한 졸업요건이 존재하지 않아, 학과를
                 선택해주셔야합니다.
               </SupportingText>
               <Label required>주전공 학과</Label>

--- a/packages/client/src/features/graduation/ui/setup/FileUploadGuide.tsx
+++ b/packages/client/src/features/graduation/ui/setup/FileUploadGuide.tsx
@@ -21,7 +21,7 @@ const FileUploadGuide = () => {
                 to="https://sjpt.sejong.ac.kr/main/view/Login/doSsoLogin.do?p="
                 target="_blank"
                 rel="noopener noreferrer"
-                className="text-primary underline font-semibold"
+                className="text-primary-500 underline font-semibold"
               >
                 학사 정보 시스템
               </NavLink>
@@ -42,14 +42,16 @@ const FileUploadGuide = () => {
 
         <div className="space-y-1 ml-1 text-gray-600 text-xs sm:text-sm">
           <p>
-            ※ 다운로드한 파일은 <span className="text-primary font-semibold">수정 없이 그대로</span> 업로드해 주세요.
+            ※ 다운로드한 파일은 <span className="text-primary-500 font-semibold">수정 없이 그대로</span> 업로드해
+            주세요.
           </p>
           <p>
-            ※ 학점이 <span className="text-primary font-semibold">F 또는 NP</span>인 과목은 저장 시{' '}
-            <span className="text-primary  font-semibold">자동으로 제외</span>됩니다.
+            ※ 학점이 <span className="text-primary-500 font-semibold">F 또는 NP</span>인 과목은 저장 시{' '}
+            <span className="text-primary-500  font-semibold">자동으로 제외</span>됩니다.
           </p>
           <p>
-            ※ 업로드한 엑셀 파일은 <span className="text-primary font-semibold">서버에 별도로 저장되지 않습니다.</span>
+            ※ 업로드한 엑셀 파일은{' '}
+            <span className="text-primary-500 font-semibold">서버에 별도로 저장되지 않습니다.</span>
           </p>
         </div>
       </Flex>

--- a/packages/client/src/features/timetable/ui/TimetableSemesterTabs.tsx
+++ b/packages/client/src/features/timetable/ui/TimetableSemesterTabs.tsx
@@ -9,7 +9,7 @@ const startIdx = SEMESTERS.findIndex(s => s.semesterCode === START_SEMESTER_CODE
 const TIMETABLE_SEMESTERS = startIdx !== -1 ? SEMESTERS.slice(0, startIdx + 1) : [];
 
 function TimetableSemesterTabs({ currentSemester }: { currentSemester?: string }) {
-  const activeClassName = 'border-b-2 border-primary text-primary pb-2';
+  const activeClassName = 'border-b-2 border-primary-500 text-primary-500 pb-2';
 
   return (
     <Flex gap="gap-4" className="border-b text-sm border-gray-200">

--- a/packages/client/src/features/user/ui/LoginForm.tsx
+++ b/packages/client/src/features/user/ui/LoginForm.tsx
@@ -104,12 +104,13 @@ function LoginForm({ onSuccess, onDepartmentNotFound }: LoginFormProps) {
 
           <Flex direction="flex-col" gap="gap-2">
             <SupportingText className="break-keep">
-              ※ <span className="font-semibold text-primary">부전공, 전과생, 연계전공, 편입생</span>의 경우 과목 인정
-              기준에 따라 일부 결과가 실제 졸업요건과 다르게 표시될 수 있습니다. 결과는{' '}
-              <span className="font-semibold text-primary">참고용</span>으로 확인해 주세요.
-              <br />※ <span className="font-semibold text-primary">비밀번호는 즉시 폐기</span>하며, 저장되지 않습니다.
+              ※ <span className="font-semibold text-primary-500">부전공, 전과생, 연계전공, 편입생</span>의 경우 과목
+              인정 기준에 따라 일부 결과가 실제 졸업요건과 다르게 표시될 수 있습니다. 결과는{' '}
+              <span className="font-semibold text-primary-500">참고용</span>으로 확인해 주세요.
+              <br />※ <span className="font-semibold text-primary-500">비밀번호는 즉시 폐기</span>하며, 저장되지
+              않습니다.
               <br />※ ALLCLL 로그인 시{' '}
-              <span className="font-semibold text-primary">학사정보시스템(세종대 포털)에서 로그아웃</span>됩니다.
+              <span className="font-semibold text-primary-500">학사정보시스템(세종대 포털)에서 로그아웃</span>됩니다.
             </SupportingText>
             <Flex
               direction="flex-col"

--- a/packages/common/src/components/graduation/CertificationSection.tsx
+++ b/packages/common/src/components/graduation/CertificationSection.tsx
@@ -87,7 +87,7 @@ function EnglishCertContent({ isPassed, onEdit }: Readonly<IEnglishCertContentPr
   return (
     <Flex direction="flex-col" align="items-center" justify="justify-center" gap="gap-1" className="h-full">
       {isPassed ? (
-        <span className="text-primary">인증 완료</span>
+        <span className="text-primary-500">인증 완료</span>
       ) : (
         <span className="text-gray-500">이수 내역 없음</span>
       )}
@@ -170,7 +170,7 @@ function CertificationSection({
           >
             <Flex justify="justify-center" align="items-center" className="h-full">
               {coding.isPassed ? (
-                <span className="text-primary">인증 완료</span>
+                <span className="text-primary-500">인증 완료</span>
               ) : (
                 <span className="text-gray-500">이수 내역 없음</span>
               )}


### PR DESCRIPTION
이 PR은 기존 PR(#387)을 대체하는 PR입니다. 기존 PR을 다시 열 수 없어 부득이하게 새로운 PR을 생성했으며, 브랜치와 커밋은 원본 그대로이므로 원본 대비 변경 사항은 없습니다.
기존 리뷰 코멘트는 #387에서 확인 부탁드립니다.

---

## 작업 내용

시간표에서 선택된 학기 밑줄이 검은색으로 나온다는 피드백이 있어 원인을 확인했습니다.

- `text-primary`, `border-primary`처럼 셰이드 없이 쓴 클래스는 CSS로 생성이 안 되고 있었습니다. primary 팔레트에 50~900만 있고 기본값이 없어서요.
- 이렇게 쓰인 곳이 시간표 탭 포함 15곳입니다 (별점, 졸업요건 인증 완료, 로그인 안내, 업로드 가이드 등). 전부 파란 강조 의도였는데 색이 적용되지 않고 있었습니다.
- 탭 밑줄만 유독 검게 보인 건 tailwind v4부터 border 기본색이 글자색(currentColor)이라서입니다.

## 변경 사항 및 리뷰 포인트

- 사용처 15곳은 전부 `primary-500`으로 셰이드를 명시했습니다. 각 코드의 의도가 드러나도록요.
- 팔레트에도 `DEFAULT: '#3B82F6'`(500과 동일)을 추가했습니다. 셰이드 없이 쓰는 습관이 이미 퍼져 있어서, 앞으로 또 나와도 조용히 깨지는 대신 의도대로 동작하게 하는 안전망입니다.
- client/admin 빌드 CSS에서 클래스 생성되는 것 확인했습니다. 셰이드 붙은 기존 사용에는 변화 없습니다.

