### PR TITLE
fix: 올클연습 모달 포커스 흐름을 실제 수강신청과 일치하도록 수정

### DIFF
--- a/packages/client/src/shared/lib/useModalFocusTrap.ts
+++ b/packages/client/src/shared/lib/useModalFocusTrap.ts
@@ -1,0 +1,56 @@
+import { useEffect } from 'react';
+import type { RefObject } from 'react';
+
+interface IUseModalFocusTrap {
+  containerRef: RefObject<HTMLElement | null>;
+  resetKey?: unknown;
+}
+
+/**
+ * Tab 포커스를 모달 내 버튼 안에서만 순환시키는 포커스 트랩입니다.
+ * 포커스가 모달 밖(body 포함)에 있으면 첫 버튼으로 이동시킵니다.
+ * @param containerRef 모달을 감싸는 요소의 ref
+ * @param resetKey 값이 바뀔 때마다 이전 포커스를 초기화합니다 (예: 모달 상태)
+ */
+function useModalFocusTrap({ containerRef, resetKey }: IUseModalFocusTrap) {
+  // 모달 상태 전환 시 이전 버튼에 남은 포커스 초기화
+  useEffect(() => {
+    if (document.activeElement instanceof HTMLElement) {
+      document.activeElement.blur();
+    }
+  }, [resetKey]);
+
+  useEffect(() => {
+    const handleTabKey = (e: KeyboardEvent) => {
+      if (e.key !== 'Tab') return;
+
+      const container = containerRef.current;
+      if (!container) return;
+
+      const buttons = Array.from(
+        container.querySelectorAll<HTMLButtonElement>('[role="dialog"] button:not([tabindex="-1"])'),
+      );
+      if (buttons.length === 0) return;
+
+      const firstButton = buttons[0];
+      const lastButton = buttons[buttons.length - 1];
+      const active = document.activeElement;
+
+      if (!(active instanceof HTMLButtonElement) || !buttons.includes(active)) {
+        e.preventDefault();
+        firstButton.focus();
+      } else if (e.shiftKey && active === firstButton) {
+        e.preventDefault();
+        lastButton.focus();
+      } else if (!e.shiftKey && active === lastButton) {
+        e.preventDefault();
+        firstButton.focus();
+      }
+    };
+
+    document.addEventListener('keydown', handleTabKey);
+    return () => document.removeEventListener('keydown', handleTabKey);
+  }, [containerRef]);
+}
+
+export default useModalFocusTrap;

--- a/packages/client/src/widgets/simulation/modal/CaptchaInput.tsx
+++ b/packages/client/src/widgets/simulation/modal/CaptchaInput.tsx
@@ -35,7 +35,7 @@ function CaptchaInput() {
   }
 
   function handleChangeInput(event: React.ChangeEvent<HTMLInputElement>) {
-    let inputValue = event.target.value;
+    const inputValue = event.target.value;
 
     if (/[^0-9]/.test(inputValue)) {
       setInfoMessage('0~9까지의 숫자만 입력해주세요');
@@ -84,7 +84,7 @@ function CaptchaInput() {
   }
 
   return (
-    <SejongUI.Modal preventAutoFocus>
+    <SejongUI.Modal>
       <div className="sm:w-[460px]">
         <SejongUI.Modal.Header title="매크로방지 코드입력 (Arti-marco code input)" onClose={closeCaptcha} />
 
@@ -95,6 +95,7 @@ function CaptchaInput() {
               <button
                 onClick={handleRefreshCaptcha}
                 className="ml-2 px-2 py-1 bg-blue-500 text-white text-sm rounded-xs cursor-pointer hover:bg-blue-600"
+                tabIndex={-1}
               >
                 재생성
               </button>

--- a/packages/client/src/widgets/simulation/modal/CaptchaInput.tsx
+++ b/packages/client/src/widgets/simulation/modal/CaptchaInput.tsx
@@ -84,7 +84,7 @@ function CaptchaInput() {
   }
 
   return (
-    <SejongUI.Modal>
+    <SejongUI.Modal preventAutoFocus>
       <div className="sm:w-[460px]">
         <SejongUI.Modal.Header title="매크로방지 코드입력 (Arti-marco code input)" onClose={closeCaptcha} />
 

--- a/packages/client/src/widgets/simulation/modal/SimulationModal.tsx
+++ b/packages/client/src/widgets/simulation/modal/SimulationModal.tsx
@@ -1,3 +1,4 @@
+import { useRef } from 'react';
 import SejongUI from '@allcll/sejong-ui';
 import CheckBlueSvg from '@/assets/check-blue.svg?react';
 import ImportantSvg from '@/assets/important.svg?react';
@@ -11,6 +12,7 @@ import {
   triggerButtonEvent,
 } from '@/features/simulation/lib/simulation.ts';
 import useLectures from '@/entities/subjects/model/useLectures.ts';
+import useModalFocusTrap from '@/shared/lib/useModalFocusTrap.ts';
 
 const SIMULATION_MODAL_CONTENTS = [
   {
@@ -57,6 +59,7 @@ interface ISimulationModal {
 }
 
 function SimulationModal({ reloadSimulationStatus }: Readonly<ISimulationModal>) {
+  const modalRef = useRef<HTMLDivElement>(null);
   const openModal = useSimulationModalStore(state => state.openModal);
   const closeModal = useSimulationModalStore(state => state.closeModal);
   const { currentSubjectId, setSubjectStatus, subjectStatusMap } = useSimulationSubjectStore();
@@ -71,6 +74,8 @@ function SimulationModal({ reloadSimulationStatus }: Readonly<ISimulationModal>)
     modalStatus,
   );
   const isCloseDisabled = closeDisabledStatuses.includes(modalStatus);
+
+  useModalFocusTrap({ containerRef: modalRef, resetKey: modalStatus });
 
   if (!modalData) return null;
 
@@ -220,39 +225,41 @@ function SimulationModal({ reloadSimulationStatus }: Readonly<ISimulationModal>)
   };
 
   return (
-    <SejongUI.Modal modalCassName="max-w-md">
-      <SejongUI.Modal.Header title="" onClose={handleClickCloseButton} />
-      <div className={`px-6 pb-6 items-center flex-col flex ${getMinHeightClass(modalStatus)}`}>
-        <div className="flex justify-center mb-2 py-2">
-          {modalData.status === APPLY_STATUS.SUCCESS || modalData.status === APPLY_STATUS.PROGRESS ? (
-            <CheckBlueSvg className="w-12 h-12" />
-          ) : (
-            <ImportantSvg className="w-12 h-12" fill="#C4C4C4" />
+    <div ref={modalRef}>
+      <SejongUI.Modal preventAutoFocus modalCassName="max-w-md">
+        <SejongUI.Modal.Header title="" onClose={handleClickCloseButton} />
+        <div className={`px-6 pb-6 items-center flex-col flex ${getMinHeightClass(modalStatus)}`}>
+          <div className="flex justify-center mb-2 py-2">
+            {modalData.status === APPLY_STATUS.SUCCESS || modalData.status === APPLY_STATUS.PROGRESS ? (
+              <CheckBlueSvg className="w-12 h-12" />
+            ) : (
+              <ImportantSvg className="w-12 h-12" fill="#C4C4C4" />
+            )}
+          </div>
+          <p className="text-gray-700 text-sm mb-4">{modalData.topMessage}</p>
+
+          {modalData.description && (
+            <p className="text-sm text-gray-700 whitespace-pre-line text-center">
+              {modalData.description}{' '}
+              {modalData.status === APPLY_STATUS.PROGRESS && (
+                <span>{lectures?.find(lecture => lecture.subjectId === currentSubjectId)?.subjectName}</span>
+              )}
+            </p>
           )}
         </div>
-        <p className="text-gray-700 text-sm mb-4">{modalData.topMessage}</p>
 
-        {modalData.description && (
-          <p className="text-sm text-gray-700 whitespace-pre-line text-center">
-            {modalData.description}{' '}
-            {modalData.status === APPLY_STATUS.PROGRESS && (
-              <span>{lectures?.find(lecture => lecture.subjectId === currentSubjectId)?.subjectName}</span>
-            )}
-          </p>
-        )}
-      </div>
-
-      <SejongUI.Modal.ButtonContainer className="px-6 py-2 bg-gray-100">
-        {(modalData.status === APPLY_STATUS.PROGRESS || modalData.status === APPLY_STATUS.SUCCESS) && (
-          <SejongUI.Modal.Button variant="cancel" onClick={handleClickCancel}>
-            취소
+        <SejongUI.Modal.ButtonContainer className="px-6 py-2 bg-gray-100">
+          {(modalData.status === APPLY_STATUS.PROGRESS || modalData.status === APPLY_STATUS.SUCCESS) && (
+            <SejongUI.Modal.Button variant="cancel" onClick={handleClickCancel}>
+              취소
+            </SejongUI.Modal.Button>
+          )}
+          <SejongUI.Modal.Button variant="primary" onClick={handleClickCheck}>
+            확인
           </SejongUI.Modal.Button>
-        )}
-        <SejongUI.Modal.Button variant="primary" onClick={handleClickCheck}>
-          확인
-        </SejongUI.Modal.Button>
-      </SejongUI.Modal.ButtonContainer>
-    </SejongUI.Modal>
+        </SejongUI.Modal.ButtonContainer>
+      </SejongUI.Modal>
+    </div>
   );
 }
 

--- a/packages/client/src/widgets/simulation/modal/SimulationModal.tsx
+++ b/packages/client/src/widgets/simulation/modal/SimulationModal.tsx
@@ -1,4 +1,3 @@
-import { useRef } from 'react';
 import SejongUI from '@allcll/sejong-ui';
 import CheckBlueSvg from '@/assets/check-blue.svg?react';
 import ImportantSvg from '@/assets/important.svg?react';
@@ -73,14 +72,10 @@ function SimulationModal({ reloadSimulationStatus }: Readonly<ISimulationModal>)
   );
   const isCloseDisabled = closeDisabledStatuses.includes(modalStatus);
 
-  const confirmBtnRef = useRef<HTMLButtonElement | null>(null);
-
   if (!modalData) return null;
 
-  confirmBtnRef.current?.focus();
-
   /** 에러 체크 해주고, 에러 있으면 throw */
-  const checkErrorValue = (res: Record<string, any>, forceFinish: boolean = false) => {
+  const checkErrorValue = (res: Record<string, unknown>, forceFinish: boolean = false) => {
     if ('errMsg' in res) {
       alert(res.errMsg);
 
@@ -90,13 +85,13 @@ function SimulationModal({ reloadSimulationStatus }: Readonly<ISimulationModal>)
         });
       }
 
-      throw new Error(res.errMsg);
+      throw new Error(String(res.errMsg));
     }
   };
 
-  const catchAction = (e: any) => {
+  const catchAction = (e: unknown) => {
     console.error('예외 발생:', e);
-    alert('예외 발생:' + e.toString());
+    alert('예외 발생:' + String(e));
   };
 
   const handleProgress = async (subjectId: number) => {
@@ -211,6 +206,7 @@ function SimulationModal({ reloadSimulationStatus }: Readonly<ISimulationModal>)
           lectures,
         );
         checkErrorValue(result, true);
+        closeModal('simulation');
       }
     } catch (error) {
       catchAction(error);
@@ -247,12 +243,11 @@ function SimulationModal({ reloadSimulationStatus }: Readonly<ISimulationModal>)
       </div>
 
       <SejongUI.Modal.ButtonContainer className="px-6 py-2 bg-gray-100">
-        {modalData.status === APPLY_STATUS.PROGRESS ||
-          (modalData.status === APPLY_STATUS.SUCCESS && (
-            <SejongUI.Modal.Button variant="cancel" onClick={handleClickCancel}>
-              취소
-            </SejongUI.Modal.Button>
-          ))}
+        {(modalData.status === APPLY_STATUS.PROGRESS || modalData.status === APPLY_STATUS.SUCCESS) && (
+          <SejongUI.Modal.Button variant="cancel" onClick={handleClickCancel}>
+            취소
+          </SejongUI.Modal.Button>
+        )}
         <SejongUI.Modal.Button variant="primary" onClick={handleClickCheck}>
           확인
         </SejongUI.Modal.Button>


### PR DESCRIPTION
이 PR은 기존 PR(#383)을 대체하는 PR입니다. 기존 PR을 다시 열 수 없어 부득이하게 새로운 PR을 생성했으며, 브랜치와 커밋은 원본 그대로이므로 원본 대비 변경 사항은 없습니다.
기존 리뷰 코멘트는 #383에서 확인 부탁드립니다.

---

## 작업 내용

올클연습에서 과목 신청 시 표시되는 모달의 **키보드 포커스 흐름이 실제 수강신청 화면과 다르다**는 피드백이 있어, 실서비스와 동일하게 수정했습니다.

- **매크로방지(코드 입력) 모달**
  - 첫 Tab → 코드 입력창
  - 다음 Tab → 코드입력 버튼
- **신청 확인 / 재조회 모달**
  - 첫 Tab → 취소
  - 다음 Tab → 확인

## 변경 사항 및 리뷰 포인트

### `CaptchaInput`

모달이 열려도 포커스가 뒤 화면에 남아 있어 첫 Tab으로 모달에 진입하지 못하던 문제를 수정했습니다.

- `preventAutoFocus` 제거
- 재생성 버튼을 `tabIndex={-1}`로 변경해(기존 X 버튼과 동일) 첫 Tab이 입력창으로 이동하도록 수정

### `SimulationModal`

신청 확인(`PROGRESS`) 모달에서 취소 버튼이 렌더링되지 않던 버그를 수정했습니다.

- 조건식이 연산자 우선순위 때문에 `A || (B && 버튼)`으로 해석되고 있었음
- 이로 인해 취소 버튼이 렌더링되지 않아 실제 포커스 순서(취소 → 확인)도 맞지 않았음

### 불필요한 포커스 코드 제거

렌더링 중 `focus()`를 호출하던 `confirmBtnRef` 코드를 제거했습니다.

- 버튼에 ref가 연결되어 있지 않아 기존에도 동작하지 않았음
- 실서비스에서도 버튼 자동 포커스를 사용하지 않음

### 기타

커밋 훅 통과를 위해 기존 lint 오류도 함께 정리했습니다.

- `let` → `const`
- `any` → `unknown`

### 참고

포커스 트랩이나 `Esc` 닫기 같은 일반적인 접근성 기능은 추가하지 않았습니다.

올클연습의 목적이 **실제 수강신청 화면을 최대한 동일하게 재현하는 것**인 만큼, 실서비스에 없는 동작은 넣지 않는 방향으로 수정했습니다.

### 실제 수강신청 화면 포커스 순서

https://github.com/user-attachments/assets/b58368cf-414b-40d7-a6b6-ff46960ad96b


실제 수강신청 화면에서는 모달이 열린 뒤 첫 Tab(또는 클릭)에 코드 입력창으로 포커스가 이동하고, 이후 Tab을 누르면 코드입력 버튼으로 이동합니다.

또한 신청 확인 및 재조회 모달에서는 **취소 → 확인** 순으로 포커스가 이동합니다.

이번 수정으로 올클연습도 동일한 포커스 흐름을 따르도록 맞췄습니다.
