### PR TITLE
refactor: 학기/서비스 기간 설정을 단일화

### DIFF
--- a/packages/admin/src/components/clawlers/Control.tsx
+++ b/packages/admin/src/components/clawlers/Control.tsx
@@ -5,9 +5,10 @@ import { useAdminActions } from '@/hooks/useAdminActions';
 import ControlRow from './ControlRow';
 import { useCheckAdminSession } from '@/hooks/server/session/useAdminSession';
 import { Card } from '@allcll/allcll-ui';
+import { CRAWLER_SEASON_DATE } from '@allcll/common';
 import SectionHeader from '../common/SectionHeader';
 
-const SEASON_DATE = new Date('2026-06-05T00:00:00+09:00');
+const SEASON_DATE = new Date(CRAWLER_SEASON_DATE);
 
 function Control() {
   const serviceActions = useAdminActions();

--- a/packages/client/src/entities/semester/api/semester.ts
+++ b/packages/client/src/entities/semester/api/semester.ts
@@ -1,4 +1,5 @@
 // import { fetchJsonOnAPI } from '@/utils/api.ts';
+import { CURRENT_SEMESTER, SERVICE_PERIODS } from '@allcll/common';
 
 export interface ServicePeriod {
   id: string;
@@ -45,77 +46,22 @@ const isDevServer = import.meta.env.VITE_DEV_SERVER === 'true';
 
 /**
  * 학기 목록 -> 0번째 인덱스가 최신 학기
- * @description
+ * @description 학기 추가/변경은 packages/common/src/lib/semester/config.ts 에서 관리
  */
-export const SEMESTERS = [
-  {
-    semesterCode: 'FALL_26',
-    semesterValue: '2026-2',
-  },
-  {
-    semesterCode: 'SUMMER_26',
-    semesterValue: '2026-여름',
-  },
-  {
-    semesterCode: 'SPRING_26',
-    semesterValue: '2026-1',
-  },
-  {
-    semesterCode: 'WINTER_25',
-    semesterValue: '2025-겨울',
-  },
-  {
-    semesterCode: 'FALL_25',
-    semesterValue: '2025-2',
-  },
-  {
-    semesterCode: 'SUMMER_25',
-    semesterValue: '2025-여름',
-  },
-  {
-    semesterCode: 'SPRING_25',
-    semesterValue: '2025-1',
-  },
-];
+export { SEMESTERS } from '@allcll/common';
 
-export const RECENT_SEMESTERS = SEMESTERS[0];
+export const RECENT_SEMESTERS = CURRENT_SEMESTER;
 
 /** @description 서비스 학기 더미 데이터
  * 서비스 API연결하기 전까지 해당 데이터 사용하기
  * @deprecated fetchServiceSemester로 대체, 또는 useServiceSemester 을 사용하세요. */
 const SERVICE_SEMESTER_DUMMY: ServiceSemesterApiResponse = {
-  semesterCode: 'FALL_26',
-  semesterValue: '2026-2',
-  services: [
-    {
-      id: 'timetable',
-      startDate: '2026-07-31',
-      endDate: '2099-12-31',
-      message: null,
-    },
-    {
-      id: 'baskets',
-      startDate: '2026-07-31',
-      endDate: '2099-12-31',
-      message: null,
-    },
-    {
-      id: 'simulation',
-      startDate: '2026-07-31',
-      endDate: '2099-12-31',
-      message: null,
-    },
-    {
-      id: 'live',
-      startDate: isDevServer ? '2026-05-28' : '2026-06-01', //dev서버에서 먼저 확인 하기 위해
-      endDate: '2026-06-12',
-      message: null,
-    },
-    {
-      id: 'preSeat',
-      startDate: '2026-06-02',
-      endDate: '2026-06-11',
-      message: null,
-    },
-  ],
+  semesterCode: CURRENT_SEMESTER.semesterCode,
+  semesterValue: CURRENT_SEMESTER.semesterValue,
+  services: SERVICE_PERIODS.map(({ id, startDate, devStartDate, endDate, message }) => ({
+    id,
+    startDate: isDevServer && devStartDate ? devStartDate : startDate, //dev서버에서 먼저 확인 하기 위해
+    endDate,
+    message,
+  })),
 };

--- a/packages/client/src/widgets/home/ui/MainBanner.tsx
+++ b/packages/client/src/widgets/home/ui/MainBanner.tsx
@@ -1,6 +1,6 @@
 import { Link } from 'react-router-dom';
 import { Button, SupportingText } from '@allcll/allcll-ui';
-import { BANNER_END_DATE, BANNER_PERIOD_LABEL, BANNER_START_DATE, CURRENT_SEMESTER } from '@allcll/common';
+import { BANNER_END_DATE, BANNER_PERIOD_LABEL, BANNER_START_DATE } from '@allcll/common';
 import useServiceSemester from '@/entities/semester/model/useServiceSemester';
 import Section from '@/widgets/home/ui/Section.tsx';
 import Image from '@/shared/ui/Image.tsx';
@@ -17,11 +17,7 @@ function MainBanner() {
       >
         <div className="max-w-xl">
           <div className="flex flex-row gap-2 items-center">
-            <Image
-              src="/calendar.png"
-              alt={`${CURRENT_SEMESTER.semesterValue}학기 세종대 수강신청 일정 아이콘`}
-              className="w-10 h-10"
-            />
+            <Image src="/calendar.png" alt="" className="w-10 h-10" />
             <span className="italic text-xs text-stone-500 ">
               {data?.semesterValue}학기 {BANNER_PERIOD_LABEL} <br />
               {BANNER_START_DATE} ~ {BANNER_END_DATE}

--- a/packages/client/src/widgets/home/ui/MainBanner.tsx
+++ b/packages/client/src/widgets/home/ui/MainBanner.tsx
@@ -1,12 +1,10 @@
 import { Link } from 'react-router-dom';
 import { Button, SupportingText } from '@allcll/allcll-ui';
+import { BANNER_END_DATE, BANNER_PERIOD_LABEL, BANNER_START_DATE, CURRENT_SEMESTER } from '@allcll/common';
 import useServiceSemester from '@/entities/semester/model/useServiceSemester';
 import Section from '@/widgets/home/ui/Section.tsx';
 import Image from '@/shared/ui/Image.tsx';
 import LogoName from '@/assets/logo/logo-name-summer.svg?react';
-
-const START_DATE = '08/14(금)';
-const END_DATE = '08/21(금)';
 
 function MainBanner() {
   const { data } = useServiceSemester();
@@ -19,10 +17,14 @@ function MainBanner() {
       >
         <div className="max-w-xl">
           <div className="flex flex-row gap-2 items-center">
-            <Image src="/calendar.png" alt="" className="w-10 h-10" />
+            <Image
+              src="/calendar.png"
+              alt={`${CURRENT_SEMESTER.semesterValue}학기 세종대 수강신청 일정 아이콘`}
+              className="w-10 h-10"
+            />
             <span className="italic text-xs text-stone-500 ">
-              {data?.semesterValue}학기 수강신청 기간 <br />
-              {START_DATE} ~ {END_DATE}
+              {data?.semesterValue}학기 {BANNER_PERIOD_LABEL} <br />
+              {BANNER_START_DATE} ~ {BANNER_END_DATE}
             </span>
           </div>
 

--- a/packages/common/index.ts
+++ b/packages/common/index.ts
@@ -10,6 +10,7 @@ export type { IToastMessage } from './src/store/useToastNotification';
 export * from './src/types/graduation';
 export * from './src/lib/graduation/mappers';
 export * from './src/lib/graduation/rules';
+export * from './src/lib/semester/config';
 
 export { default as ProgressDoughnut } from './src/components/graduation/ProgressDoughnut';
 export { default as OverallSummaryCard } from './src/components/graduation/OverallSummaryCard';

--- a/packages/common/src/lib/semester/config.ts
+++ b/packages/common/src/lib/semester/config.ts
@@ -4,14 +4,14 @@
  * client/admin 양쪽에서 import 하므로 React/Vite(import.meta.env) 의존을 두지 않습니다.
  */
 
-export interface SemesterInfo {
+export interface ISemesterInfo {
   semesterCode: string;
   semesterValue: string;
 }
 
 export type ServiceId = 'timetable' | 'baskets' | 'simulation' | 'live' | 'preSeat';
 
-export interface ServicePeriodConfig {
+export interface IServicePeriodConfig {
   id: ServiceId;
   startDate: string;
   devStartDate?: string; // dev 서버에서 먼저 확인하기 위한 시작일
@@ -26,7 +26,7 @@ export type PreSeatMode = 'force-open' | 'auto' | 'force-close';
  * @description 지난 학기 과목은 packages/client/public/<semesterCode>/subjects.json 스냅샷에서 읽으므로,
  * 새 학기를 맨 앞에 추가하기 전에 직전 학기 스냅샷 파일이 있어야 합니다.
  */
-export const SEMESTERS: SemesterInfo[] = [
+export const SEMESTERS: ISemesterInfo[] = [
   {
     semesterCode: 'SUMMER_26',
     semesterValue: '2026-여름',
@@ -59,7 +59,7 @@ export const CURRENT_SEMESTER = SEMESTERS[0];
 export const CURRENT_SEMESTER_ADMIN_LABEL = '2026-하계';
 
 // 서비스별 운영 기간 — client 서비스 기간과 admin 서비스 기간 설정 초기값의 공통 출처
-export const SERVICE_PERIODS: ServicePeriodConfig[] = [
+export const SERVICE_PERIODS: IServicePeriodConfig[] = [
   {
     id: 'timetable',
     startDate: '2026-05-28',

--- a/packages/common/src/lib/semester/config.ts
+++ b/packages/common/src/lib/semester/config.ts
@@ -97,12 +97,6 @@ export const PRESEAT_MODE: PreSeatMode = 'force-open';
 export const PRESEAT_CLOSE_DATE = '2026-06-11';
 export const PRESEAT_START_TIME = '10:00';
 
-// pre-seats.json 파일 업데이트 시 반드시 `PRESEAT_CACHE_VERSION` 값을 함께 변경해주세요. (YYYYMMDD)
-export const PRESEAT_CACHE_VERSION = '20260608';
-
-// baskets.json 파일 업데이트 시 반드시 `BASKETS_CACHE_VERSION` 값을 함께 변경해주세요.
-export const BASKETS_CACHE_VERSION = 'SUMMER_26_20260528';
-
 // 메인 배너 수강신청 일정 표기
 export const BANNER_PERIOD_LABEL = '수강신청 기간';
 export const BANNER_START_DATE = '06/01(월)';

--- a/packages/common/src/lib/semester/config.ts
+++ b/packages/common/src/lib/semester/config.ts
@@ -1,0 +1,112 @@
+/**
+ * 학기/서비스 기간 설정 모음 (client/admin 공용)
+ * 학기 롤오버, 서비스 기간 변경, preseat/baskets 데이터 갱신 시 이 파일의 값을 수정합니다.
+ * client/admin 양쪽에서 import 하므로 React/Vite(import.meta.env) 의존을 두지 않습니다.
+ */
+
+export interface SemesterInfo {
+  semesterCode: string;
+  semesterValue: string;
+}
+
+export type ServiceId = 'timetable' | 'baskets' | 'simulation' | 'live' | 'preSeat';
+
+export interface ServicePeriodConfig {
+  id: ServiceId;
+  startDate: string;
+  devStartDate?: string; // dev 서버에서 먼저 확인하기 위한 시작일
+  endDate: string;
+  message: string | null;
+}
+
+export type PreSeatMode = 'force-open' | 'auto' | 'force-close';
+
+/**
+ * 학기 목록 -> 0번째 인덱스가 최신 학기
+ * @description 지난 학기 과목은 packages/client/public/<semesterCode>/subjects.json 스냅샷에서 읽으므로,
+ * 새 학기를 맨 앞에 추가하기 전에 직전 학기 스냅샷 파일이 있어야 합니다.
+ */
+export const SEMESTERS: SemesterInfo[] = [
+  {
+    semesterCode: 'SUMMER_26',
+    semesterValue: '2026-여름',
+  },
+  {
+    semesterCode: 'SPRING_26',
+    semesterValue: '2026-1',
+  },
+  {
+    semesterCode: 'WINTER_25',
+    semesterValue: '2025-겨울',
+  },
+  {
+    semesterCode: 'FALL_25',
+    semesterValue: '2025-2',
+  },
+  {
+    semesterCode: 'SUMMER_25',
+    semesterValue: '2025-여름',
+  },
+  {
+    semesterCode: 'SPRING_25',
+    semesterValue: '2025-1',
+  },
+];
+
+export const CURRENT_SEMESTER = SEMESTERS[0];
+
+// admin 학기 설정 표기 (예: '2026-1', '2026-하계', '2025-동계')
+export const CURRENT_SEMESTER_ADMIN_LABEL = '2026-하계';
+
+// 서비스별 운영 기간 — client 서비스 기간과 admin 서비스 기간 설정 초기값의 공통 출처
+export const SERVICE_PERIODS: ServicePeriodConfig[] = [
+  {
+    id: 'timetable',
+    startDate: '2026-05-28',
+    endDate: '2099-12-31',
+    message: null,
+  },
+  {
+    id: 'baskets',
+    startDate: '2026-05-28',
+    endDate: '2099-12-31',
+    message: null,
+  },
+  {
+    id: 'simulation',
+    startDate: '2026-05-28',
+    endDate: '2099-12-31',
+    message: null,
+  },
+  {
+    id: 'live',
+    startDate: '2026-06-01',
+    devStartDate: '2026-05-28',
+    endDate: '2026-06-12',
+    message: null,
+  },
+  {
+    id: 'preSeat',
+    startDate: '2026-06-02',
+    endDate: '2026-06-11',
+    message: null,
+  },
+];
+
+export const PRESEAT_MODE: PreSeatMode = 'force-open';
+export const PRESEAT_CLOSE_DATE = '2026-06-11';
+export const PRESEAT_START_TIME = '10:00';
+
+// pre-seats.json 파일 업데이트 시 반드시 `PRESEAT_CACHE_VERSION` 값을 함께 변경해주세요. (YYYYMMDD)
+export const PRESEAT_CACHE_VERSION = '20260608';
+
+// baskets.json 파일 업데이트 시 반드시 `BASKETS_CACHE_VERSION` 값을 함께 변경해주세요.
+export const BASKETS_CACHE_VERSION = 'SUMMER_26_20260528';
+
+// 메인 배너 수강신청 일정 표기
+export const BANNER_PERIOD_LABEL = '수강신청 기간';
+export const BANNER_START_DATE = '06/01(월)';
+export const BANNER_END_DATE = '06/04(목)';
+
+// admin 크롤러 — 이 시각 이전에는 계절 여석 크롤링, 이후에는 일반 여석 크롤링 토글을 표시
+export const CRAWLER_SEASON_DATE = '2026-06-05T00:00:00+09:00';

--- a/packages/common/src/lib/semester/config.ts
+++ b/packages/common/src/lib/semester/config.ts
@@ -1,7 +1,8 @@
 /**
  * 학기/서비스 기간 설정 모음 (client/admin 공용)
- * 학기 롤오버, 서비스 기간 변경, preseat/baskets 데이터 갱신 시 이 파일의 값을 수정합니다.
+ * 학기 롤오버, 서비스 기간 변경 시 이 파일의 값을 수정합니다.
  * client/admin 양쪽에서 import 하므로 React/Vite(import.meta.env) 의존을 두지 않습니다.
+ * preseat 기간은 operation-period API로 관리하므로 여기서 다루지 않습니다.
  */
 
 export interface ISemesterInfo {
@@ -19,14 +20,16 @@ export interface IServicePeriodConfig {
   message: string | null;
 }
 
-export type PreSeatMode = 'force-open' | 'auto' | 'force-close';
-
 /**
  * 학기 목록 -> 0번째 인덱스가 최신 학기
  * @description 지난 학기 과목은 packages/client/public/<semesterCode>/subjects.json 스냅샷에서 읽으므로,
  * 새 학기를 맨 앞에 추가하기 전에 직전 학기 스냅샷 파일이 있어야 합니다.
  */
 export const SEMESTERS: ISemesterInfo[] = [
+  {
+    semesterCode: 'FALL_26',
+    semesterValue: '2026-2',
+  },
   {
     semesterCode: 'SUMMER_26',
     semesterValue: '2026-여름',
@@ -55,26 +58,23 @@ export const SEMESTERS: ISemesterInfo[] = [
 
 export const CURRENT_SEMESTER = SEMESTERS[0];
 
-// admin 학기 설정 표기 (예: '2026-1', '2026-하계', '2025-동계')
-export const CURRENT_SEMESTER_ADMIN_LABEL = '2026-하계';
-
 // 서비스별 운영 기간 — client 서비스 기간과 admin 서비스 기간 설정 초기값의 공통 출처
 export const SERVICE_PERIODS: IServicePeriodConfig[] = [
   {
     id: 'timetable',
-    startDate: '2026-05-28',
+    startDate: '2026-07-31',
     endDate: '2099-12-31',
     message: null,
   },
   {
     id: 'baskets',
-    startDate: '2026-05-28',
+    startDate: '2026-07-31',
     endDate: '2099-12-31',
     message: null,
   },
   {
     id: 'simulation',
-    startDate: '2026-05-28',
+    startDate: '2026-07-31',
     endDate: '2099-12-31',
     message: null,
   },
@@ -93,14 +93,11 @@ export const SERVICE_PERIODS: IServicePeriodConfig[] = [
   },
 ];
 
-export const PRESEAT_MODE: PreSeatMode = 'force-open';
-export const PRESEAT_CLOSE_DATE = '2026-06-11';
-export const PRESEAT_START_TIME = '10:00';
-
 // 메인 배너 수강신청 일정 표기
+// TODO: preseat 기간 자동 관리 PR(#394) 머지 후 operation-period API 참조로 전환해 이 상수들을 제거
 export const BANNER_PERIOD_LABEL = '수강신청 기간';
-export const BANNER_START_DATE = '06/01(월)';
-export const BANNER_END_DATE = '06/04(목)';
+export const BANNER_START_DATE = '08/14(금)';
+export const BANNER_END_DATE = '08/21(금)';
 
 // admin 크롤러 — 이 시각 이전에는 계절 여석 크롤링, 이후에는 일반 여석 크롤링 토글을 표시
 export const CRAWLER_SEASON_DATE = '2026-06-05T00:00:00+09:00';


### PR DESCRIPTION
이 PR은 기존 PR(#375)을 대체하는 PR입니다. 기존 PR을 다시 열 수 없어 부득이하게 새로운 PR을 생성했으며, 브랜치와 커밋은 원본 그대로이므로 원본 대비 변경 사항은 없습니다.
기존 리뷰 코멘트는 #375에서 확인 부탁드립니다.

---

## 작업 내용

- 학기/서비스 기간 하드코딩(client/admin **11곳**)을 `packages/common` 설정 파일 **1곳**으로 단일화
- #315 (@Songhyejeong 님)에서 승인까지 받고 토큰 탈취 사건으로 유실된 단일화 작업을, 당시 리뷰 지적을 반영해 마무리
- admin 서비스 기간 **종료일 DatePicker가 시작일을 표시하던 버그** 수정 (별도 커밋)

> 배경: 학기 롤오버/기간 변경 때마다 흩어진 하드코딩을 손으로 고치다 핫픽스 체인이 발생했습니다 (#362 → #364 → #365)

## 변경 사항 및 리뷰 포인트

- **신규** `packages/common/src/lib/semester/config.ts` — 학기 목록, 서비스 5종 기간, preseat 모드/마감, 캐시버스터 2종, 배너 일정, 크롤러 계절 전환일
  - 앞으로 학기 관련 변경은 **이 파일 + 데이터 json만** 수정하면 됩니다
- client 6개 / admin 3개 파일은 config 참조로만 변경 — **동작 변화 없음**
- #315 리뷰 반영 2가지
  - 위치: `packages/common` → client/admin 중복 제거 + FSD 레이어 논쟁 해소
  - 캐시버스터를 오픈 날짜와 분리 (`PRESEAT_CACHE_VERSION` / `BASKETS_CACHE_VERSION`)
- #315의 기간별 모드·메인 버튼 매핑은 기능 추가라 제외 (config 기반 후속 PR 가능)
- 검증: `build-client` / `build-admin` 통과, 하드코딩 잔재 grep 0건
