### PR TITLE
fix: 관심과목 분석 페이지 관심 인원 필터 나오지 않는 문제 해결

### DIFF
--- a/packages/client/src/widgets/filtering/ui/WishFilter.tsx
+++ b/packages/client/src/widgets/filtering/ui/WishFilter.tsx
@@ -49,9 +49,10 @@ function WishFilter() {
     .map(cat => cat);
   const allSelectedFilters = getAllSelectedLabels(filters);
 
-  const hasPreSeats = !!(subjects && 'seat' in subjects);
+  const hasPreSeats = !!(subjects && subjects[0] && 'seat' in subjects[0]);
+
   const { isPreSeatAvailable } = usePreSeatGate({ hasSeats: hasPreSeats });
-  const isWishesAvailable = subjects && 'totalCount' in subjects;
+  const isWishesAvailable = subjects && subjects[0] && 'totalCount' in subjects[0];
 
   const setToggleFavorite = () => setFilter('favoriteOnly', !favoriteOnly);
 


### PR DESCRIPTION
## 작업 내용
관심과목 분석 페이지 내 관심 인원 필터가 나오지 않는 문제를 해결합니다.
### 원인
기존 로직의 경우 `'seat | totalCount' in subjects` 로직이 항상 false를 반환하여 해당 필터가 항상 표시되지 않는 문제가 있었습니다.

### 해결
따라서 기존 동일 로직을 사용하는 `useHeaderSelector` 내 로직을 적용하여 해결했습니다.
https://github.com/allcll/allcll-frontend/blob/2e61369a253adc257b436118c52409b247f64975/packages/client/src/features/wish/lib/useHeaderSelector.ts#L8-L11

## 변경 사항 및 리뷰 포인트
As-Is:
<img width="1137" height="151" alt="image" src="https://github.com/user-attachments/assets/38b902d2-cd4e-454b-a309-6655499e3d76" />
To-Be:
<img width="1137" height="325" alt="image" src="https://github.com/user-attachments/assets/5d1ca9eb-fef5-4855-bbc0-4e086648e820" />
