### PR TITLE
fix: 과목 선택 모드 재클릭 시 과목 목록이 사라지는 문제 수정

### DIFF
--- a/packages/client/src/widgets/simulation/modal/before/UserWishModal.tsx
+++ b/packages/client/src/widgets/simulation/modal/before/UserWishModal.tsx
@@ -122,6 +122,9 @@ function UserWishModal({ timetables, setIsModalOpen }: Readonly<UserWishModalIPr
    * @returns
    */
   const handleClickSubjectMode = (mode: ModeType) => {
+    // 같은 모드를 다시 눌렀을 때 과목 목록이 비워지는 것을 방지한다.
+    if (mode === subjectMode) return;
+
     setSimulationSubjects([]);
     setSubjectMode(mode);
   };


### PR DESCRIPTION
## 작업 내용

올클연습 시작 전 과목 선택 모달에서, **이미 선택된 과목 모드 칩을 다시 누르면 과목 목록이 사라지는** 문제를 수정했습니다. `기존 과목` / `시간표 과목` / `랜덤 과목` 세 모드 모두에서 발생합니다.

## 원인

과목 목록을 **비우는 곳과 채우는 곳이 분리**되어 있습니다. 비우기는 칩을 누를 때마다 실행되지만,

```tsx
const handleClickSubjectMode = (mode: ModeType) => {
  setSimulationSubjects([]);  // 클릭할 때마다 실행
  setSubjectMode(mode);
};
```

채우기는 모드가 **바뀔 때만** 도는 effect 안에 있습니다.

```tsx
useEffect(() => {
  if (subjectMode !== 'random') return;
  setSimulationSubjects(pickNonRandomSubjects(lectures, department.departmentName));
}, [subjectMode, department]);
```

이미 선택된 칩을 다시 누르면 `setSubjectMode` 에 같은 값이 들어가 React 가 상태 변경으로 보지 않습니다. 의존성도 그대로라 effect 가 재실행되지 않고, 결국 비우기만 실행된 채 끝납니다.

```
칩 클릭 → 목록 비우기 → 모드 변경 → effect 실행 → 목록 채우기
                          ↑ 같은 값이라       ↑ 여기까지 오지 못함
                            무시됨
```

세 모드의 effect 가 모두 `subjectMode` 를 의존성에 두고 있어 동일하게 발생합니다.

## 변경 사항

이미 선택된 모드면 무시하도록 가드를 추가했습니다. 랜덤 모드에는 다시 뽑기용 `랜덤과목 재생성` 버튼이 따로 있어 역할이 겹치지 않습니다.
